### PR TITLE
docs: fix broken installation URLs and simplify installation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,10 +317,7 @@ npm install -g bunx ccusage
 #### Method 1: Automated Install Script (Recommended)
 
 ```bash
-# Download and run the automated installer (latest stable)
-curl -fsSL https://raw.githubusercontent.com/rz1989s/claude-code-statusline/v1.2.0/install.sh | bash
-
-# Or install the latest development version
+# Download and run the automated installer
 curl -fsSL https://raw.githubusercontent.com/rz1989s/claude-code-statusline/main/install.sh | bash
 
 # Or download and inspect before running


### PR DESCRIPTION
## Summary

Fix broken installation documentation that was causing 404 errors for new users trying to install the statusline.

## What Changed

- **Remove broken v1.2.0 installation URL** - The `curl` command pointing to `v1.2.0/install.sh` was causing 404 errors since no git tag exists
- **Eliminate confusing version choices** - Both "stable" and "development" installation methods were identical, causing unnecessary confusion
- **Streamline installation process** - Single, clear installation method using the `main` branch
- **Improve user experience** - Remove misleading documentation that suggested version-specific installations

## Impact

- ✅ **Fixes user installation issues** - No more 404 errors when following README instructions
- 📚 **Clearer documentation** - Single installation path reduces confusion
- 🔧 **Better maintainability** - No need to maintain version-specific installation URLs

## Changes Made

```diff
- # Download and run the automated installer (latest stable)
- curl -fsSL https://raw.githubusercontent.com/rz1989s/claude-code-statusline/v1.2.0/install.sh | bash
- 
- # Or install the latest development version
+ # Download and run the automated installer
  curl -fsSL https://raw.githubusercontent.com/rz1989s/claude-code-statusline/main/install.sh | bash
```

## Test Plan

- [x] Verified README.md changes are correct
- [x] Confirmed single installation method works properly  
- [x] Checked that no other files reference broken v1.2.0 URLs
- [x] Validated all documentation is consistent

🤝 Ready for review and merge to fix user installation experience.