### PR TITLE
fix: resolve stat command syntax errors on Linux (Issue #57)

### DIFF
--- a/lib/prayer/location.sh
+++ b/lib/prayer/location.sh
@@ -162,8 +162,9 @@ load_cached_location() {
         return 1
     fi
     
-    # Check cache age
-    local cache_age=$(($(date +%s) - $(stat -c %Y "$cache_file" 2>/dev/null || echo 0)))
+    # Check cache age (cross-platform)
+    local cache_mtime=$(get_file_mtime "$cache_file")
+    local cache_age=$(($(date +%s) - cache_mtime))
     if [[ $cache_age -gt $cache_ttl ]]; then
         debug_log "Cached location data expired (${cache_age}s > ${cache_ttl}s)" "INFO"
         rm -f "$cache_file" 2>/dev/null

--- a/lib/prayer_original_backup.sh
+++ b/lib/prayer_original_backup.sh
@@ -378,17 +378,11 @@ load_cached_location() {
         return 1
     fi
     
-    # Check cache age
+    # Check cache age (cross-platform)
     if command_exists stat; then
-        local file_age
-        if [[ "$(uname)" == "Darwin" ]]; then
-            # macOS stat format
-            file_age=$(( $(date +%s) - $(stat -f %m "$cache_file" 2>/dev/null || echo 0) ))
-        else
-            # Linux stat format  
-            file_age=$(( $(date +%s) - $(stat -c %Y "$cache_file" 2>/dev/null || echo 0) ))
-        fi
-        
+        local cache_mtime=$(get_file_mtime "$cache_file")
+        local file_age=$(( $(date +%s) - cache_mtime ))
+
         if [[ $file_age -gt $cache_duration_seconds ]]; then
             debug_log "Cached location data is too old (${file_age}s), ignoring" "INFO"
             return 1


### PR DESCRIPTION
## Summary
Fixes critical cross-platform compatibility bug where BSD/GNU `stat` command differences caused "syntax error in expression" failures on Linux systems.

## Problem
Issue #57 reported by @polczak-itt on Kubuntu 25.10:
```
/home/piotr/.claude/statusline/lib/security.sh: line 375: 1762957229 - File: "/home/piotr/.cache/claude-code-statusline/cmd_exists_git_piotr_claude_statusline.cache"
...
syntax error in expression (error token is ": \"/home/piotr/.cache/...\"")
```

**Root Cause:**
- `stat -f` (BSD/macOS format) returns **filesystem info** on Linux (not file info)
- Multi-line error output was inserted into bash arithmetic expressions
- Example: `local age=$(($(date +%s) - $(stat -f %m "$file" || stat -c %Y "$file")))`
- On Linux, `stat -f` output polluted the arithmetic context → syntax error

## Solution
Created three platform-aware helper functions in `lib/security.sh`:
- `get_file_mtime()` - Get file modification time (returns Unix timestamp)
- `get_file_permissions()` - Get file permissions (returns octal like "644")
- `get_file_size()` - Get file size in bytes

**Design:**
- Try BSD format first (`stat -f`), then fallback to GNU format (`stat -c`)
- Return clean numeric values with proper error handling
- Prevent stderr pollution in arithmetic contexts
- Fully cross-platform (macOS, Linux, BSD systems)

## Changes
Updated all `stat` command usages across the codebase:
- `lib/security.sh` - 3 locations (permissions check, cache freshness, lock cleanup)
- `lib/cache.sh` - 2 locations (lock age, file size calculation)
- `lib/prayer/location.sh` - 1 location (cache age check)
- `lib/prayer_original_backup.sh` - 1 location (cache age check)

## Testing
- ✅ Security tests pass (cache file handling verified)
- ✅ Statusline works correctly on macOS  
- ⏳ Awaiting Linux testing by @polczak-itt

## Deployment Plan
1. Merge to `nightly` for testing
2. Request @polczak-itt to test on Kubuntu 25.10
3. After confirmation, promote to `main`

Fixes #57