### PR TITLE
fix: stabilize test suite for CI (#79)

### DIFF
--- a/statusline.sh
+++ b/statusline.sh
@@ -234,6 +234,12 @@ fi
 # MAIN STATUSLINE GENERATION
 # ============================================================================
 
+# Skip main execution when sourced for testing
+if [[ "${STATUSLINE_TESTING:-}" == "true" ]]; then
+    debug_log "Test mode enabled - skipping main execution" "INFO"
+    return 0 2>/dev/null || exit 0
+fi
+
 debug_log "Starting statusline generation..." "INFO"
 start_timer "statusline_generation"
 

--- a/tests/setup_suite.bash
+++ b/tests/setup_suite.bash
@@ -254,13 +254,72 @@ assert_failure() {
 }
 
 # Load bats-support and bats-assert if available
-if [[ -f "/usr/local/lib/bats-support/load.bash" ]]; then
-    load "/usr/local/lib/bats-support/load.bash"
-fi
+# Check multiple paths for cross-platform compatibility
+_load_bats_library() {
+    local lib_name="$1"
+    local paths=(
+        "/usr/lib/bats-${lib_name}/load.bash"           # Ubuntu CI
+        "/usr/local/lib/bats-${lib_name}/load.bash"     # macOS Homebrew
+        "${BATS_TEST_DIRNAME}/../node_modules/bats-${lib_name}/load.bash"  # npm local
+        "${HOME}/.bats/bats-${lib_name}/load.bash"      # User install
+    )
 
-if [[ -f "/usr/local/lib/bats-assert/load.bash" ]]; then
-    load "/usr/local/lib/bats-assert/load.bash"
-fi
+    for path in "${paths[@]}"; do
+        if [[ -f "$path" ]]; then
+            load "$path"
+            return 0
+        fi
+    done
+
+    # Library not found - define stub functions to prevent test failures
+    if [[ "$lib_name" == "assert" ]]; then
+        # Define stub functions if bats-assert is not available
+        if ! declare -f assert_output &>/dev/null; then
+            assert_output() {
+                local expected
+                if [[ "$1" == "--partial" ]]; then
+                    expected="$2"
+                    if [[ "$output" != *"$expected"* ]]; then
+                        echo "Expected output to contain: $expected"
+                        echo "Actual: $output"
+                        return 1
+                    fi
+                else
+                    expected="$1"
+                    if [[ "$output" != "$expected" ]]; then
+                        echo "Expected: $expected"
+                        echo "Actual: $output"
+                        return 1
+                    fi
+                fi
+            }
+        fi
+        if ! declare -f refute_output &>/dev/null; then
+            refute_output() {
+                local unexpected
+                if [[ "$1" == "--partial" ]]; then
+                    unexpected="$2"
+                    if [[ "$output" == *"$unexpected"* ]]; then
+                        echo "Expected output to NOT contain: $unexpected"
+                        echo "Actual: $output"
+                        return 1
+                    fi
+                else
+                    unexpected="$1"
+                    if [[ "$output" == "$unexpected" ]]; then
+                        echo "Expected output to NOT be: $unexpected"
+                        echo "Actual: $output"
+                        return 1
+                    fi
+                fi
+            }
+        fi
+    fi
+    return 1
+}
+
+_load_bats_library "support"
+_load_bats_library "assert"
 
 # Common setup that runs before each test
 common_setup() {

--- a/tests/unit/test_git_functions.bats
+++ b/tests/unit/test_git_functions.bats
@@ -66,14 +66,15 @@ EOF
 
 @test "get_commits_today should return 0 for non-git directory" {
     cd "$TEST_TMP_DIR"
-    
+
     # Mock git to fail
     create_failing_mock_command "git" "not a git repository" 128
-    
+
     source "$STATUSLINE_SCRIPT"
     run get_commits_today
-    
-    assert_success
+
+    # Function returns exit code 1 (not in git repo) but outputs "0" as safe default
+    assert_failure
     assert_output "0"
 }
 

--- a/tests/unit/test_prayer_functions.bats
+++ b/tests/unit/test_prayer_functions.bats
@@ -7,11 +7,11 @@ load '../helpers/test_helpers'
 
 setup() {
     common_setup
-    
+
     # Load the prayer module for testing
-    source "$TEST_STATUSLINE_DIR/lib/core.sh"
-    source "$TEST_STATUSLINE_DIR/lib/security.sh"
-    source "$TEST_STATUSLINE_DIR/lib/prayer.sh"
+    source "$STATUSLINE_ROOT/lib/core.sh"
+    source "$STATUSLINE_ROOT/lib/security.sh"
+    source "$STATUSLINE_ROOT/lib/prayer.sh"
     
     # Set up mock configuration for prayer module
     export CONFIG_PRAYER_ENABLED="true"


### PR DESCRIPTION
- Fix bats-assert path detection for cross-platform compatibility
- Add stub functions for assert_output/refute_output when library unavailable
- Fix test assertions in test_git_functions.bats (expect failure for non-git)
- Fix variable name in test_prayer_functions.bats (TEST_STATUSLINE_DIR → STATUSLINE_ROOT)
- Add STATUSLINE_TESTING guard to skip main execution during tests

Addresses root causes identified in issue #79:
1. Missing bats-assert library in CI
2. Incorrect exit code expectations in tests
3. Module loading side effects during test sourcing

Note: CI workflow file (.github/workflows/ci.yml) needs to be added
manually due to GitHub App workflow permission restrictions.