### PR TITLE
fix(homebrew): formula installation fixes for v2.12.0

### DIFF
--- a/homebrew/claude-code-statusline.rb
+++ b/homebrew/claude-code-statusline.rb
@@ -16,6 +16,9 @@ class ClaudeCodeStatusline < Formula
   depends_on "coreutils" if OS.mac?  # For gtimeout
 
   def install
+    # Install config template BEFORE moving files to libexec
+    (share/"claude-code-statusline").install "examples/Config.toml"
+
     # Install all files to libexec
     libexec.install Dir["*"]
 
@@ -24,9 +27,6 @@ class ClaudeCodeStatusline < Formula
       #!/bin/bash
       exec "#{libexec}/statusline.sh" "$@"
     EOS
-
-    # Install config template from examples directory
-    (share/"claude-code-statusline").install "examples/Config.toml"
   end
 
   def post_install


### PR DESCRIPTION
## Summary
- Fix Config.toml path from root to `examples/Config.toml`
- Install Config.toml before moving files to libexec (order fix)

## Test Plan
- [x] Tested `brew install rz1989s/tap/claude-code-statusline`
- [x] Verified `claude-statusline --version` shows 2.12.0
- [x] Confirmed Config.toml installed correctly