### PR TITLE
fix(cache): suppress noclobber lock error messages

### DIFF
--- a/lib/cache/locking.sh
+++ b/lib/cache/locking.sh
@@ -38,10 +38,11 @@ acquire_cache_lock() {
         [[ -f "$lock_file" ]] && rm -f "$lock_file" 2>/dev/null
 
         # Try to acquire lock atomically
+        # Note: redirect entire subshell stderr to suppress noclobber errors
         if (
             set -C
-            echo "$CACHE_INSTANCE_ID:$$:$(date +%s)" >"$lock_file" 2>/dev/null
-        ); then
+            echo "$CACHE_INSTANCE_ID:$$:$(date +%s)" >"$lock_file"
+        ) 2>/dev/null; then
             [[ "${STATUSLINE_CORE_LOADED:-}" == "true" ]] && debug_log "Acquired cache lock: $(basename "$cache_file")" "INFO"
             return 0
         else


### PR DESCRIPTION
## Summary

Fixes stderr messages appearing during lock acquisition:
```
lib/cache/locking.sh: line 43: ...lock: cannot overwrite existing file
```

## Fix

Move stderr redirect from `echo` command to the subshell level to properly suppress `set -C` noclobber error messages.

```bash
# Before (error not suppressed)
if (
    set -C
    echo "..." >"$lock_file" 2>/dev/null
); then

# After (error suppressed at subshell level)  
if (
    set -C
    echo "..." >"$lock_file"
) 2>/dev/null; then
```

## Test Plan

- [x] Tested in lumos, sip-protocol, claude-code-statusline repos
- [x] No error messages in output
- [x] REPO costs display correctly

Hotfix - please merge.