### PR TITLE
feat: usage_limits and usage_reset components with reset countdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Smart fallback: Automatically uses native percentages when available (v2.1.6+), falls back to transcript parsing for older versions
 - `COMPONENT_CONTEXT_REMAINING` and `COMPONENT_CONTEXT_SOURCE` variables for richer context data
 - **Usage limits component** (`usage_limits`): Display Claude Code rate limits (5h session, 7d weekly) from Anthropic OAuth API
-- New functions: `get_claude_oauth_token()`, `fetch_usage_limits()`, `collect_usage_limits_data()`, `render_usage_limits()`, `format_reset_time()`
-- Display format: `Limit: 5h:22%(↻2h15m) 7d:54%(↻Jan18)` with color-coded thresholds and reset countdowns
-- Reset time display: Shows relative time (<24h: "2h15m") or date (>24h: "Jan18") with configurable `show_reset_times` option
+- **Usage reset component** (`usage_reset`): Separate component for reset countdown display
+- New functions: `get_claude_oauth_token()`, `fetch_usage_limits()`, `collect_usage_limits_data()`, `render_usage_limits()`, `render_usage_reset()`, `format_reset_time()`
+- Display format (Line 3): `Limit: 5h:22% 7d:54%` with color-coded thresholds
+- Display format (Line 4): `Reset: 5h:2h15m 7d:Jan18` with reset countdown
+- Reset time formatting: Shows relative time (<24h: "2h15m") or date (>24h: "Jan18")
 - GitHub Actions CI/CD workflow for automated testing
 - Pre-commit hooks configuration (.pre-commit-config.yaml)
 - Architecture documentation with Mermaid diagrams

--- a/examples/Config.toml
+++ b/examples/Config.toml
@@ -140,16 +140,17 @@ context_window.medium_threshold = 50   # Yellow medium (50-75%)
 
 # === USAGE LIMITS CONFIGURATION (v2.15.0) ===
 # Display Claude Code rate limit usage from Anthropic OAuth API.
-# Shows 5-hour session and 7-day weekly usage percentages with optional reset times.
+# Shows 5-hour session and 7-day weekly usage percentages.
 # Reference: https://codelynx.dev/posts/claude-code-usage-limits-statusline
 #
-# Display format: Limit: 5h:22%(↻2h15m) 7d:54%(↻Jan18)
+# Display format (Line 3): Limit: 5h:22% 7d:54%
+# Display format (Line 4): Reset: 5h:2h15m 7d:Jan18
 features.show_usage_limits = true
-usage_limits.label = "Limit:"          # Label prefix
+usage_limits.label = "Limit:"          # Label prefix for percentages
+usage_limits.reset_label = "Reset:"    # Label prefix for reset countdown
 usage_limits.warn_threshold = 50       # Yellow warning above this %
 usage_limits.critical_threshold = 80   # Red critical above this %
 usage_limits.cache_ttl = 300           # API cache TTL in seconds (5 min)
-usage_limits.show_reset_times = true   # Show reset countdown (e.g., "↻2h15m")
 
 # === SESSION INFO CONFIGURATION (Issue #102) ===
 # Display session identification for multi-session awareness.
@@ -465,7 +466,7 @@ display.line3.separator = " │ "
 display.line3.show_when_empty = true
 
 # Line 4: System Status & Timer
-display.line4.components = ["mcp_status", "reset_timer"]
+display.line4.components = ["mcp_status", "reset_timer", "usage_reset"]
 display.line4.separator = " │ "
 display.line4.show_when_empty = true
 


### PR DESCRIPTION
## Summary
- **Usage limits component** (`usage_limits`): Display Claude Code rate limits (5h session, 7d weekly) from Anthropic OAuth API
- **Usage reset component** (`usage_reset`): Separate component for reset countdown display
- Display format (Line 3): `Limit: 5h:26% 7d:54%` with color-coded thresholds
- Display format (Line 4): `Reset: 5h:2h15m 7d:Jan18` with reset countdown
- Cross-platform date parsing (macOS + Linux)

## Test plan
- [x] Verify OAuth token extraction from keychain
- [x] Test API fetch with caching
- [x] Verify format_reset_time() relative/date formatting
- [x] Test both components render separately
- [x] Confirm color thresholds work (green <50%, yellow 50-79%, red ≥80%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)