### PR TITLE
feat(usage_limits): combined format with reset time + percentage

### DIFF
--- a/examples/Config.toml
+++ b/examples/Config.toml
@@ -460,7 +460,7 @@ display.line2.separator = " │ "
 display.line2.show_when_empty = true
 
 # Line 3: Block Metrics + Context + Usage Limits (v2.15.0: added usage_limits, removed token_usage)
-display.line3.components = ["burn_rate", "cache_efficiency", "block_projection", "context_window", "usage_limits"]
+display.line3.components = ["burn_rate", "cache_efficiency", "block_projection", "context_window"]
 display.line3.separator = " │ "
 display.line3.show_when_empty = true
 

--- a/lib/components/usage_limits.sh
+++ b/lib/components/usage_limits.sh
@@ -97,6 +97,67 @@ format_reset_time() {
     fi
 }
 
+# Format reset time in long format: "1 hr 52 min" or "Sun 8:00 AM"
+format_reset_time_long() {
+    local iso_timestamp="$1"
+
+    if [[ -z "$iso_timestamp" || "$iso_timestamp" == "null" ]]; then
+        echo ""
+        return 1
+    fi
+
+    # Parse ISO timestamp to epoch
+    local reset_epoch
+    local normalized_ts
+    normalized_ts=$(echo "$iso_timestamp" | sed 's/\.[0-9]*//')
+
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        local mac_ts
+        mac_ts=$(echo "$normalized_ts" | sed 's/+00:00/+0000/; s/Z$/+0000/; s/+\([0-9][0-9]\):\([0-9][0-9]\)/+\1\2/')
+        reset_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%S%z" "$mac_ts" "+%s" 2>/dev/null)
+    else
+        reset_epoch=$(date -d "$iso_timestamp" "+%s" 2>/dev/null)
+    fi
+
+    if [[ -z "$reset_epoch" ]]; then
+        echo ""
+        return 1
+    fi
+
+    local now_epoch
+    now_epoch=$(date "+%s")
+    local diff_seconds=$((reset_epoch - now_epoch))
+
+    # If already past, return "now"
+    if [[ "$diff_seconds" -le 0 ]]; then
+        echo "now"
+        return 0
+    fi
+
+    # Format based on time remaining
+    if [[ "$diff_seconds" -lt 3600 ]]; then
+        # Less than 1 hour: show minutes
+        local minutes=$((diff_seconds / 60))
+        echo "${minutes} min"
+    elif [[ "$diff_seconds" -lt 86400 ]]; then
+        # Less than 24 hours: show hours and minutes in long format
+        local hours=$((diff_seconds / 3600))
+        local minutes=$(((diff_seconds % 3600) / 60))
+        if [[ "$minutes" -gt 0 ]]; then
+            echo "${hours} hr ${minutes} min"
+        else
+            echo "${hours} hr"
+        fi
+    else
+        # More than 24 hours: show day + time (e.g., "Sun 8:00 AM")
+        if [[ "$(uname -s)" == "Darwin" ]]; then
+            date -j -f "%s" "$reset_epoch" "+%a %-I:%M %p" 2>/dev/null
+        else
+            date -d "@$reset_epoch" "+%a %-I:%M %p" 2>/dev/null
+        fi
+    fi
+}
+
 # ============================================================================
 # OAUTH TOKEN RETRIEVAL
 # ============================================================================
@@ -280,48 +341,72 @@ render_usage_limits() {
 # USAGE RESET COMPONENT (Separate display for reset countdown)
 # ============================================================================
 
-# Render usage reset times (separate component for line 4)
-# Uses ⏱ timer emoji with bullet separator
+# Render combined usage info (reset time + percentage) for line 4
+# Format: ⏱ 5H 1 hr 52 min (28%) • 7DAY Sun 8:00 AM (55%)
 render_usage_reset() {
     local theme_enabled="${1:-true}"
 
-    # Skip if no reset data available
-    if [[ -z "$COMPONENT_USAGE_FIVE_HOUR_RESET" && -z "$COMPONENT_USAGE_SEVEN_DAY_RESET" ]]; then
+    # Skip if no data available
+    if [[ -z "$COMPONENT_USAGE_FIVE_HOUR" && -z "$COMPONENT_USAGE_SEVEN_DAY" ]]; then
         return 1  # No content - skip this component
     fi
 
-    local output=""
-    local dim_color=""
-    local reset_color=""
+    # Get colors
+    local cyan_color="" dim_color="" green_color="" yellow_color="" red_color="" reset_color=""
+    local warn_threshold="${CONFIG_USAGE_WARN_THRESHOLD:-50}"
+    local critical_threshold="${CONFIG_USAGE_CRITICAL_THRESHOLD:-80}"
 
     if [[ "$theme_enabled" == "true" ]] && is_module_loaded "themes"; then
-        dim_color="${CONFIG_LIGHT_GRAY:-}"
-        reset_color="${COLOR_RESET:-}"
+        cyan_color="${CONFIG_CYAN:-\033[36m}"
+        dim_color="${CONFIG_LIGHT_GRAY:-\033[90m}"
+        green_color="${CONFIG_GREEN:-\033[32m}"
+        yellow_color="${CONFIG_YELLOW:-\033[33m}"
+        red_color="${CONFIG_RED:-\033[31m}"
+        reset_color="${COLOR_RESET:-\033[0m}"
     fi
 
-    # Build output with reset times (⏱ timer emoji)
-    if [[ -n "$COMPONENT_USAGE_FIVE_HOUR_RESET" ]]; then
-        local formatted_reset
-        formatted_reset=$(format_reset_time "$COMPONENT_USAGE_FIVE_HOUR_RESET")
-        if [[ -n "$formatted_reset" ]]; then
-            output="⏱ ${dim_color}5h:${formatted_reset}${reset_color}"
+    local output=""
+
+    # 5-hour window
+    if [[ -n "$COMPONENT_USAGE_FIVE_HOUR" ]]; then
+        local pct_color="$green_color"
+        if [[ "$COMPONENT_USAGE_FIVE_HOUR" -ge "$critical_threshold" ]]; then
+            pct_color="$red_color"
+        elif [[ "$COMPONENT_USAGE_FIVE_HOUR" -ge "$warn_threshold" ]]; then
+            pct_color="$yellow_color"
         fi
+
+        local reset_time=""
+        if [[ -n "$COMPONENT_USAGE_FIVE_HOUR_RESET" ]]; then
+            reset_time=$(format_reset_time_long "$COMPONENT_USAGE_FIVE_HOUR_RESET")
+        fi
+
+        output="⏱ ${cyan_color}5H${reset_color} ${dim_color}${reset_time}${reset_color} ${pct_color}(${COMPONENT_USAGE_FIVE_HOUR}%)${reset_color}"
     fi
 
-    if [[ -n "$COMPONENT_USAGE_SEVEN_DAY_RESET" ]]; then
-        local formatted_reset
-        formatted_reset=$(format_reset_time "$COMPONENT_USAGE_SEVEN_DAY_RESET")
-        if [[ -n "$formatted_reset" ]]; then
-            if [[ -n "$output" ]]; then
-                output="${output} • ${dim_color}7d:${formatted_reset}${reset_color}"
-            else
-                output="⏱ ${dim_color}7d:${formatted_reset}${reset_color}"
-            fi
+    # 7-day window
+    if [[ -n "$COMPONENT_USAGE_SEVEN_DAY" ]]; then
+        local pct_color="$green_color"
+        if [[ "$COMPONENT_USAGE_SEVEN_DAY" -ge "$critical_threshold" ]]; then
+            pct_color="$red_color"
+        elif [[ "$COMPONENT_USAGE_SEVEN_DAY" -ge "$warn_threshold" ]]; then
+            pct_color="$yellow_color"
+        fi
+
+        local reset_time=""
+        if [[ -n "$COMPONENT_USAGE_SEVEN_DAY_RESET" ]]; then
+            reset_time=$(format_reset_time_long "$COMPONENT_USAGE_SEVEN_DAY_RESET")
+        fi
+
+        if [[ -n "$output" ]]; then
+            output="${output} • ${cyan_color}7DAY${reset_color} ${dim_color}${reset_time}${reset_color} ${pct_color}(${COMPONENT_USAGE_SEVEN_DAY}%)${reset_color}"
+        else
+            output="⏱ ${cyan_color}7DAY${reset_color} ${dim_color}${reset_time}${reset_color} ${pct_color}(${COMPONENT_USAGE_SEVEN_DAY}%)${reset_color}"
         fi
     fi
 
     if [[ -n "$output" ]]; then
-        echo "$output"
+        echo -e "$output"
         return 0
     fi
 
@@ -393,7 +478,7 @@ register_component \
     "true"
 
 # Export component functions
-export -f get_claude_oauth_token fetch_usage_limits format_reset_time
+export -f get_claude_oauth_token fetch_usage_limits format_reset_time format_reset_time_long
 export -f collect_usage_limits_data render_usage_limits render_usage_reset get_usage_limits_config
 
 debug_log "Usage limits component loaded" "INFO"


### PR DESCRIPTION
## Summary
- Combines usage limit info into single line format
- Format: `⏱ 5H 1 hr 39 min (29%) • 7DAY Sun 8:00 AM (55%)`
- Color scheme: cyan labels, dim time, colored percentages (green <50%, yellow 50-79%, red 80%+)
- Fixes UTC timezone parsing on macOS

## Changes
- Add `format_reset_time_long()` for human-readable time format
- Update `render_usage_reset()` to combine percentage + reset time
- Remove `usage_limits` from line 3 (consolidated to line 4)

## Test plan
- [x] Function tests pass for both time formats
- [x] Live API data renders correctly
- [x] UTC parsing works correctly on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)