### PR TITLE
fix(cache): CONFIG_DISPLAY_LINES + usage_reset clock time

### DIFF
--- a/lib/config/cache.sh
+++ b/lib/config/cache.sh
@@ -159,8 +159,9 @@ CACHE_HEADER
         map(
             "export CONFIG_" +
             (.key | gsub("\\."; "_") | ascii_upcase |
-             # Strip DISPLAY_ prefix for line configurations
-             gsub("^DISPLAY_LINE"; "LINE")) +
+             # Strip DISPLAY_ prefix only for line configurations with numbers (LINE1, LINE2, etc.)
+             # But keep DISPLAY_LINES intact for display.lines setting
+             if test("^DISPLAY_LINE[0-9]") then gsub("^DISPLAY_"; "") else . end) +
             "=" +
             (if .value == null then "\"\""
              elif .value | type == "string" then "\"" + (.value | gsub("\""; "\\\"")) + "\""


### PR DESCRIPTION
## Summary
- Fix cache regex that incorrectly converted `display.lines` to `CONFIG_LINES` instead of `CONFIG_DISPLAY_LINES`
- Add "at HH:MM" clock time display for 5H usage reset
- Use monochrome styling (light gray + italic) for usage_reset

## Bug Fixed
`gsub("^DISPLAY_LINE"; "LINE")` was matching `DISPLAY_LINES` and stripping the prefix incorrectly.
Result: `display.lines=6` was ignored, so line 6 (location_display) never rendered.

## Format
```
⏱ 5H at 13:00 (1 hr 17 min) 32% • 7DAY Sun 8:00 AM (56%)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)