### PR TITLE
Merge dev into nightly: restore code_productivity + fix usage_reset

### DIFF
--- a/examples/Config.toml
+++ b/examples/Config.toml
@@ -464,8 +464,8 @@ display.line3.components = ["burn_rate", "cache_efficiency", "block_projection",
 display.line3.separator = " │ "
 display.line3.show_when_empty = true
 
-# Line 4: System Status & Usage Limits (includes reset timer)
-display.line4.components = ["mcp_status", "usage_limits"]
+# Line 4: System Status & Reset Timer (detailed reset countdown)
+display.line4.components = ["mcp_status", "usage_reset"]
 display.line4.separator = " │ "
 display.line4.show_when_empty = true
 

--- a/lib/components/usage_limits.sh
+++ b/lib/components/usage_limits.sh
@@ -314,6 +314,11 @@ collect_usage_limits_data() {
     return 0
 }
 
+# Alias for usage_reset component (shares same data as usage_limits)
+collect_usage_reset_data() {
+    collect_usage_limits_data
+}
+
 # ============================================================================
 # COMPONENT RENDERING
 # ============================================================================
@@ -498,6 +503,6 @@ register_component \
 
 # Export component functions
 export -f get_claude_oauth_token fetch_usage_limits format_reset_time format_reset_time_long
-export -f collect_usage_limits_data render_usage_limits render_usage_reset get_usage_limits_config
+export -f collect_usage_limits_data collect_usage_reset_data render_usage_limits render_usage_reset get_usage_limits_config
 
 debug_log "Usage limits component loaded" "INFO"


### PR DESCRIPTION
## Summary
- Restored `code_productivity` component to default line3 (LOC edit display `+X/-Y`)
- Fixed ghost `usage_reset` component by adding missing `collect_usage_reset_data` function
- Updated Config.toml comments for clarity

## Commits
- `89eeae6` fix(config): restore code_productivity component to default line3
- `93be2b8` fix(config): replace ghost usage_reset with usage_limits in line4
- `6f80baa` fix(usage_reset): add missing collect_usage_reset_data function

## Test plan
- [x] `--modules` shows no warnings
- [x] Line 3 includes code_productivity
- [x] usage_reset component works properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)