### PR TITLE
Release: restore code_productivity + fix usage_reset

### DIFF
--- a/examples/Config.toml
+++ b/examples/Config.toml
@@ -459,12 +459,12 @@ display.line2.components = ["model_info", "cost_repo", "cost_monthly", "cost_wee
 display.line2.separator = " │ "
 display.line2.show_when_empty = true
 
-# Line 3: Block Metrics + Context + Usage Limits (v2.15.0: added usage_limits, removed token_usage)
-display.line3.components = ["burn_rate", "cache_efficiency", "block_projection", "context_window"]
+# Line 3: Block Metrics + Code Stats + Context (v2.15.0: restored code_productivity)
+display.line3.components = ["burn_rate", "cache_efficiency", "block_projection", "code_productivity", "context_window"]
 display.line3.separator = " │ "
 display.line3.show_when_empty = true
 
-# Line 4: System Status & Timer
+# Line 4: System Status & Reset Timer (detailed reset countdown)
 display.line4.components = ["mcp_status", "usage_reset"]
 display.line4.separator = " │ "
 display.line4.show_when_empty = true

--- a/lib/components/usage_limits.sh
+++ b/lib/components/usage_limits.sh
@@ -314,6 +314,11 @@ collect_usage_limits_data() {
     return 0
 }
 
+# Alias for usage_reset component (shares same data as usage_limits)
+collect_usage_reset_data() {
+    collect_usage_limits_data
+}
+
 # ============================================================================
 # COMPONENT RENDERING
 # ============================================================================
@@ -498,6 +503,6 @@ register_component \
 
 # Export component functions
 export -f get_claude_oauth_token fetch_usage_limits format_reset_time format_reset_time_long
-export -f collect_usage_limits_data render_usage_limits render_usage_reset get_usage_limits_config
+export -f collect_usage_limits_data collect_usage_reset_data render_usage_limits render_usage_reset get_usage_limits_config
 
 debug_log "Usage limits component loaded" "INFO"


### PR DESCRIPTION
## Summary
- Restored `code_productivity` component to default line3 (LOC edit display `+X/-Y`)
- Fixed ghost `usage_reset` component by adding missing `collect_usage_reset_data` function

## Changes
- Line 3 default components now include `code_productivity` for `+lines/-lines` display
- `usage_reset` component properly implemented with collect function alias

## Test plan
- [x] `--modules` shows no warnings
- [x] Line 3 includes code_productivity
- [x] usage_reset component works properly
- [ ] Fresh install from main branch works

🤖 Generated with [Claude Code](https://claude.com/claude-code)