### PR TITLE
v2.16.0: Native cost calculation with API-synced LIVE

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  # GitHub Actions - keep workflows secure
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  # npm - devDependencies only (bats)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore"
+    labels:
+      - "dependencies"
+      - "npm"
+    open-pull-requests-limit: 3

--- a/install.sh
+++ b/install.sh
@@ -749,6 +749,7 @@ download_directory_comprehensive() {
     local cost_modules=(
         "cost/core.sh" "cost/ccusage.sh" "cost/blocks.sh" "cost/aggregation.sh"
         "cost/native.sh" "cost/alerts.sh" "cost/session.sh"
+        "cost/api_live.sh" "cost/native_calc.sh"
         # 🆕 ADD NEW COST MODULES HERE (lib/cost/*.sh files)
     )
 
@@ -1054,6 +1055,7 @@ download_lib_fallback() {
     local cost_modules=(
         "cost/core.sh" "cost/ccusage.sh" "cost/blocks.sh" "cost/aggregation.sh"
         "cost/native.sh" "cost/alerts.sh" "cost/session.sh"
+        "cost/api_live.sh" "cost/native_calc.sh"
         # 🆕 ADD NEW COST MODULES HERE (must match optimized function arrays)
     )
 

--- a/lib/components/cost_daily.sh
+++ b/lib/components/cost_daily.sh
@@ -24,22 +24,23 @@ collect_cost_daily_data() {
     # Initialize default
     COMPONENT_COST_DAILY_AMOUNT="-.--"
     
-    if is_module_loaded "cost" && is_ccusage_available; then
+    if is_module_loaded "cost"; then
         # Get usage info and parse daily cost
+        # Uses native JSONL calculation (primary) or ccusage (fallback)
         local usage_info
         usage_info=$(get_claude_usage_info)
-        
+
         if [[ -n "$usage_info" ]]; then
             # Parse usage info (format: session:month:week:today:block:reset)
             local remaining="$usage_info"
-            
+
             # Skip session cost
             remaining="${remaining#*:}"
             # Skip month cost
             remaining="${remaining#*:}"
-            # Skip week cost  
+            # Skip week cost
             remaining="${remaining#*:}"
-            
+
             # Extract today cost
             COMPONENT_COST_DAILY_AMOUNT="${remaining%%:*}"
         fi

--- a/lib/components/cost_monthly.sh
+++ b/lib/components/cost_monthly.sh
@@ -24,18 +24,19 @@ collect_cost_monthly_data() {
     # Initialize default
     COMPONENT_COST_MONTHLY_AMOUNT="-.--"
     
-    if is_module_loaded "cost" && is_ccusage_available; then
+    if is_module_loaded "cost"; then
         # Get usage info and parse monthly cost
+        # Uses native JSONL calculation (primary) or ccusage (fallback)
         local usage_info
         usage_info=$(get_claude_usage_info)
-        
+
         if [[ -n "$usage_info" ]]; then
             # Parse usage info (format: session:month:week:today:block:reset)
             local remaining="$usage_info"
-            
+
             # Skip session cost
             remaining="${remaining#*:}"
-            
+
             # Extract month cost
             COMPONENT_COST_MONTHLY_AMOUNT="${remaining%%:*}"
         fi

--- a/lib/components/cost_repo.sh
+++ b/lib/components/cost_repo.sh
@@ -30,18 +30,13 @@ collect_cost_repo_data() {
 
     if is_module_loaded "cost"; then
         # REPO shows cumulative repository cost (all sessions in this repo)
-        # This is different from SESSION cost which shows current conversation only.
-        # Always use ccusage session data for cumulative repo cost.
-        if is_ccusage_available; then
-            local usage_info
-            usage_info=$(get_claude_usage_info)
+        # Uses native JSONL calculation (primary) or ccusage (fallback)
+        local usage_info
+        usage_info=$(get_claude_usage_info)
 
-            if [[ -n "$usage_info" ]]; then
-                COMPONENT_COST_REPO_COST="${usage_info%%:*}"
-                debug_log "Using ccusage for cumulative repo cost: \$$COMPONENT_COST_REPO_COST" "INFO"
-            fi
-        else
-            debug_log "ccusage not available for repo cost" "WARN"
+        if [[ -n "$usage_info" ]]; then
+            COMPONENT_COST_REPO_COST="${usage_info%%:*}"
+            debug_log "Repo cost: \$$COMPONENT_COST_REPO_COST" "INFO"
         fi
     fi
 

--- a/lib/components/cost_weekly.sh
+++ b/lib/components/cost_weekly.sh
@@ -24,20 +24,21 @@ collect_cost_weekly_data() {
     # Initialize default
     COMPONENT_COST_WEEKLY_AMOUNT="-.--"
     
-    if is_module_loaded "cost" && is_ccusage_available; then
+    if is_module_loaded "cost"; then
         # Get usage info and parse weekly cost
+        # Uses native JSONL calculation (primary) or ccusage (fallback)
         local usage_info
         usage_info=$(get_claude_usage_info)
-        
+
         if [[ -n "$usage_info" ]]; then
             # Parse usage info (format: session:month:week:today:block:reset)
             local remaining="$usage_info"
-            
+
             # Skip session cost
             remaining="${remaining#*:}"
             # Skip month cost
             remaining="${remaining#*:}"
-            
+
             # Extract week cost
             COMPONENT_COST_WEEKLY_AMOUNT="${remaining%%:*}"
         fi

--- a/lib/cost.sh
+++ b/lib/cost.sh
@@ -4,18 +4,20 @@
 # Claude Code Statusline - Cost Tracking Module (Facade)
 # ============================================================================
 #
-# This module handles all cost tracking and billing information using
-# ccusage integration, including session costs, daily/weekly/monthly totals,
-# and active billing block management.
+# This module handles all cost tracking and billing information.
+# Primary: Native JSONL calculation (no external dependencies)
+# Fallback: ccusage integration (deprecated)
 #
 # Architecture: Thin facade that sources modular sub-components
-# - cost/core.sh       - Constants, session tracking, cache validation
-# - cost/ccusage.sh    - ccusage availability and execution
+# - cost/core.sh        - Constants, session tracking, cache validation
+# - cost/api_live.sh    - Pricing lookup, API-synced LIVE calculation
+# - cost/native_calc.sh - Native JSONL cost calculation (all periods)
+# - cost/ccusage.sh     - ccusage availability (deprecated fallback)
 # - cost/aggregation.sh - Date calculations, cost data retrieval
-# - cost/blocks.sh     - Block processing, unified metrics
-# - cost/native.sh     - Native Anthropic JSON extraction
-# - cost/session.sh    - Session info, transcript parsing
-# - cost/alerts.sh     - Cost threshold alerts, notifications
+# - cost/blocks.sh      - Block processing, unified metrics
+# - cost/native.sh      - Native Anthropic JSON extraction
+# - cost/session.sh     - Session info, transcript parsing
+# - cost/alerts.sh      - Cost threshold alerts, notifications
 #
 # Error Suppression Patterns (Issue #76):
 # - jq empty 2>/dev/null: JSON validation where invalid data returns fallback
@@ -82,6 +84,18 @@ source "${COST_LIB_DIR}/cost/alerts.sh" 2>/dev/null || {
     return 1
 }
 
+# shellcheck source=cost/api_live.sh
+source "${COST_LIB_DIR}/cost/api_live.sh" 2>/dev/null || {
+    debug_log "Failed to load cost/api_live.sh (optional)" "WARN"
+    # Not fatal - API-synced LIVE is optional enhancement
+}
+
+# shellcheck source=cost/native_calc.sh
+source "${COST_LIB_DIR}/cost/native_calc.sh" 2>/dev/null || {
+    debug_log "Failed to load cost/native_calc.sh (optional)" "WARN"
+    # Not fatal - will fallback to ccusage
+}
+
 # ============================================================================
 # FILE-BASED CACHE FOR STATUSLINE RENDER (Issue #147)
 # ============================================================================
@@ -98,6 +112,7 @@ _COST_RENDER_CACHE_FILE="${TMPDIR:-/tmp}/.statusline_cost_render_$$"
 # Get comprehensive Claude usage information
 # This is the main entry point for cost data
 # Performance: Caches result per statusline render (Issue #147)
+# Strategy: Native JSONL calculation (primary) → ccusage (fallback)
 get_claude_usage_info() {
     # Fast path: Return cached result if file exists and is fresh (<30 seconds old)
     # This eliminates 6 redundant calls (~12s saved)
@@ -116,31 +131,56 @@ get_claude_usage_info() {
 
     start_timer "cost_tracking"
 
-    # Fast mock data for testing (skips all ccusage calls)
+    # Fast mock data for testing
     if [[ "${STATUSLINE_MOCK_COST_DATA:-}" == "true" ]]; then
         end_timer "cost_tracking"
-        local result="0.00:0.00:0.00:0.00:No ccusage:Mock mode"
+        local result="0.00:0.00:0.00:0.00:No data:Mock mode"
         echo "$result" > "$_COST_RENDER_CACHE_FILE"
         echo "$result"
         return 0
     fi
 
-    # Check if ccusage is available
+    local result=""
+
+    # =========================================================================
+    # PRIMARY: Native JSONL calculation (no external dependencies)
+    # =========================================================================
+    if declare -f get_cached_native_usage_info &>/dev/null; then
+        debug_log "Using native JSONL cost calculation (primary)" "INFO"
+
+        local current_dir="${STATUSLINE_WORKING_DIR:-$(pwd)}"
+        result=$(get_cached_native_usage_info "$current_dir")
+
+        if [[ -n "$result" && "$result" != *"-.--"* ]]; then
+            local tracking_time
+            tracking_time=$(end_timer "cost_tracking")
+            debug_log "Native cost tracking completed in ${tracking_time}s" "INFO"
+            echo "$result" > "$_COST_RENDER_CACHE_FILE"
+            echo "$result"
+            return 0
+        fi
+
+        debug_log "Native calculation returned empty/invalid, trying ccusage fallback" "WARN"
+    fi
+
+    # =========================================================================
+    # FALLBACK: ccusage-based calculation (deprecated)
+    # =========================================================================
     if ! is_ccusage_available; then
-        local result="-.--:-.--:-.--:-.--:$CONFIG_NO_CCUSAGE_MESSAGE:$CONFIG_CCUSAGE_INSTALL_MESSAGE"
+        local result="-.--:-.--:-.--:-.--:${CONFIG_NO_CCUSAGE_MESSAGE:-No data}:Native calc unavailable"
         echo "$result" > "$_COST_RENDER_CACHE_FILE"
         end_timer "cost_tracking"
         echo "$result"
         return 0
     fi
+
+    debug_log "Using ccusage for cost calculation (fallback)" "INFO"
 
     # Initialize cache
     init_cost_cache
 
-    # Get all cost data in parallel (via caching system)
+    # Get all cost data via ccusage
     local session_data daily_data monthly_data block_data
-
-    debug_log "Fetching cost data..." "INFO"
 
     session_data=$(get_session_cost_data)
     daily_data=$(get_daily_cost_data)
@@ -163,10 +203,10 @@ get_claude_usage_info() {
 
     local tracking_time
     tracking_time=$(end_timer "cost_tracking")
-    debug_log "Cost tracking completed in ${tracking_time}s" "INFO"
+    debug_log "ccusage cost tracking completed in ${tracking_time}s" "INFO"
 
-    # Cache and return the formatted string (Issue #147)
-    local result="${session_cost}:${month_cost}:${week_cost}:${today_cost}:${block_cost_info}:${reset_info}"
+    # Cache and return the formatted string
+    result="${session_cost}:${month_cost}:${week_cost}:${today_cost}:${block_cost_info}:${reset_info}"
     echo "$result" > "$_COST_RENDER_CACHE_FILE"
     echo "$result"
 }
@@ -177,26 +217,29 @@ get_claude_usage_info() {
 
 # Initialize the cost tracking module
 init_cost_module() {
-    debug_log "Cost tracking module initialized (modular architecture)" "INFO"
+    debug_log "Cost tracking module initialized (native primary, ccusage fallback)" "INFO"
 
-    # Check ccusage availability
-    if ! is_ccusage_available; then
-        handle_warning "ccusage not available - cost tracking disabled" "init_cost_module"
-        debug_log "To enable cost tracking: npm install -g ccusage" "INFO"
-        return 1
+    # Check native calculation availability (primary)
+    if declare -f get_native_usage_info &>/dev/null; then
+        debug_log "Native JSONL cost calculation available (primary)" "INFO"
+    else
+        debug_log "Native cost calculation not loaded" "WARN"
     fi
 
-    # Initialize cache
-    init_cost_cache
+    # Check ccusage availability (fallback)
+    if is_ccusage_available; then
+        debug_log "ccusage available as fallback" "INFO"
+        # Initialize cache for ccusage fallback
+        init_cost_cache
 
-    # Log ccusage version for debugging (using universal caching)
-    local ccusage_version
-    if [[ "${STATUSLINE_CACHE_LOADED:-}" == "true" ]]; then
-        ccusage_version=$(cache_external_command "ccusage_version" "$CACHE_DURATION_VERY_LONG" "validate_command_output" bunx ccusage --version)
-        debug_log "ccusage version: $ccusage_version (cached)" "INFO"
+        # Log ccusage version for debugging
+        if [[ "${STATUSLINE_CACHE_LOADED:-}" == "true" ]]; then
+            local ccusage_version
+            ccusage_version=$(cache_external_command "ccusage_version" "$CACHE_DURATION_VERY_LONG" "validate_command_output" bunx ccusage --version)
+            debug_log "ccusage version: $ccusage_version (cached)" "INFO"
+        fi
     else
-        ccusage_version=$(bunx ccusage --version 2>/dev/null)
-        debug_log "ccusage version: $ccusage_version" "INFO"
+        debug_log "ccusage not available - using native calculation only" "INFO"
     fi
 
     return 0

--- a/lib/cost/api_live.sh
+++ b/lib/cost/api_live.sh
@@ -1,0 +1,269 @@
+#!/bin/bash
+
+# ============================================================================
+# Claude Code Statusline - API-Synced LIVE Cost Module
+# ============================================================================
+#
+# Calculates LIVE cost by reading JSONL files within the Anthropic API's
+# 5-hour billing window. This ensures LIVE syncs with the reset timer.
+#
+# Data Sources:
+# - Anthropic OAuth API: Gets 5-hour window boundaries (resets_at)
+# - Local JSONL files: Reads token usage from ~/.claude/projects/
+#
+# Pricing (per million tokens):
+# - Opus 4.5: Input $5, Output $25, Cache Write $6.25, Cache Read $0.50
+# - Sonnet 4.5: Input $3, Output $15, Cache Write $3.75, Cache Read $0.30
+# - Haiku 4.5: Input $1, Output $5, Cache Write $1.25, Cache Read $0.10
+#
+# Dependencies: usage_limits.sh (for OAuth token), jq
+# ============================================================================
+
+# Prevent multiple includes
+[[ "${STATUSLINE_COST_API_LIVE_LOADED:-}" == "true" ]] && return 0
+export STATUSLINE_COST_API_LIVE_LOADED=true
+
+# ============================================================================
+# PRICING LOOKUP (bash 3.x compatible - no associative arrays)
+# ============================================================================
+# Prices per million tokens
+
+# Get model pricing (returns: input output cache_write cache_read)
+# Uses case statement for bash 3.x compatibility (macOS default bash)
+get_model_pricing() {
+    local model="$1"
+
+    case "$model" in
+        claude-opus-4-5-20251101)
+            echo "5.00 25.00 6.25 0.50"
+            ;;
+        claude-sonnet-4-5-20251101|claude-sonnet-4-20250514)
+            echo "3.00 15.00 3.75 0.30"
+            ;;
+        claude-haiku-4-5-20251101)
+            echo "1.00 5.00 1.25 0.10"
+            ;;
+        *)
+            # Default to Opus pricing for safety
+            echo "5.00 25.00 6.25 0.50"
+            ;;
+    esac
+}
+
+# Cache TTL for API-synced LIVE (30 seconds)
+API_LIVE_CACHE_TTL="${API_LIVE_CACHE_TTL:-30}"
+
+# ============================================================================
+# JSONL DIRECTORY DISCOVERY
+# ============================================================================
+
+# Get Claude projects directory path
+get_claude_projects_dir() {
+    local projects_dir=""
+
+    # Check environment variable first
+    if [[ -n "${CLAUDE_CONFIG_DIR:-}" ]]; then
+        projects_dir="${CLAUDE_CONFIG_DIR}/projects"
+    elif [[ -d "$HOME/.claude/projects" ]]; then
+        projects_dir="$HOME/.claude/projects"
+    elif [[ -d "$HOME/.config/claude/projects" ]]; then
+        projects_dir="$HOME/.config/claude/projects"
+    fi
+
+    echo "$projects_dir"
+}
+
+# ============================================================================
+# COST CALCULATION
+# ============================================================================
+
+# Calculate cost for a single entry based on token usage
+# Args: model, input_tokens, output_tokens, cache_write_tokens, cache_read_tokens
+calculate_entry_cost() {
+    local model="$1"
+    local input_tokens="${2:-0}"
+    local output_tokens="${3:-0}"
+    local cache_write_tokens="${4:-0}"
+    local cache_read_tokens="${5:-0}"
+
+    # Get pricing for model (space-separated: input output cache_write cache_read)
+    local pricing
+    pricing=$(get_model_pricing "$model")
+
+    # Parse pricing values
+    local input_price output_price cache_write_price cache_read_price
+    read -r input_price output_price cache_write_price cache_read_price <<< "$pricing"
+
+    # Calculate cost (prices are per million tokens)
+    local cost
+    cost=$(awk -v it="$input_tokens" -v ip="$input_price" \
+               -v ot="$output_tokens" -v op="$output_price" \
+               -v cwt="$cache_write_tokens" -v cwp="$cache_write_price" \
+               -v crt="$cache_read_tokens" -v crp="$cache_read_price" \
+        'BEGIN {
+            input_cost = it * ip / 1000000
+            output_cost = ot * op / 1000000
+            cache_write_cost = cwt * cwp / 1000000
+            cache_read_cost = crt * crp / 1000000
+            total = input_cost + output_cost + cache_write_cost + cache_read_cost
+            printf "%.6f", total
+        }' 2>/dev/null)
+
+    echo "${cost:-0}"
+}
+
+# ============================================================================
+# API-SYNCED LIVE CALCULATION
+# ============================================================================
+
+# Get the 5-hour window start time from API's resets_at
+# Returns: Unix epoch timestamp of window start
+get_api_window_start() {
+    # Get resets_at from usage_limits component (already fetched and cached)
+    local resets_at="${COMPONENT_USAGE_FIVE_HOUR_RESET:-}"
+
+    if [[ -z "$resets_at" || "$resets_at" == "null" ]]; then
+        # Try fetching directly if component data not available
+        local usage_data
+        usage_data=$(fetch_usage_limits 2>/dev/null)
+        resets_at=$(echo "$usage_data" | jq -r '.five_hour.resets_at // empty' 2>/dev/null)
+    fi
+
+    if [[ -z "$resets_at" || "$resets_at" == "null" ]]; then
+        debug_log "No API resets_at available for LIVE calculation" "WARN"
+        echo ""
+        return 1
+    fi
+
+    # Parse resets_at to epoch
+    local reset_epoch
+    local normalized_ts
+    normalized_ts=$(echo "$resets_at" | sed 's/\.[0-9]*//')
+
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        local mac_ts
+        mac_ts=$(echo "$normalized_ts" | sed 's/+00:00/+0000/; s/Z$/+0000/; s/+\([0-9][0-9]\):\([0-9][0-9]\)/+\1\2/')
+        reset_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%S%z" "$mac_ts" "+%s" 2>/dev/null)
+    else
+        reset_epoch=$(date -d "$resets_at" "+%s" 2>/dev/null)
+    fi
+
+    if [[ -z "$reset_epoch" ]]; then
+        debug_log "Could not parse API resets_at: $resets_at" "WARN"
+        echo ""
+        return 1
+    fi
+
+    # Calculate window start (5 hours before reset)
+    local window_start=$((reset_epoch - 5 * 3600))
+    echo "$window_start"
+}
+
+# Calculate LIVE cost from JSONL files within API's 5-hour window
+# OPTIMIZED: Single jq+awk pipeline (no per-entry jq calls)
+# Returns: Total cost in USD (e.g., "18.51")
+calculate_api_synced_live() {
+    local projects_dir
+    projects_dir=$(get_claude_projects_dir)
+
+    if [[ -z "$projects_dir" || ! -d "$projects_dir" ]]; then
+        debug_log "Claude projects directory not found" "WARN"
+        echo "0.00"
+        return 1
+    fi
+
+    local window_start_epoch
+    window_start_epoch=$(get_api_window_start)
+
+    if [[ -z "$window_start_epoch" ]]; then
+        debug_log "Could not determine API window start" "WARN"
+        echo "0.00"
+        return 1
+    fi
+
+    # Convert epoch to ISO format for string comparison
+    local window_start_iso
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        window_start_iso=$(date -u -r "$window_start_epoch" "+%Y-%m-%dT%H:%M:%S" 2>/dev/null)
+    else
+        window_start_iso=$(date -u -d "@$window_start_epoch" "+%Y-%m-%dT%H:%M:%S" 2>/dev/null)
+    fi
+
+    debug_log "API LIVE window start: $window_start_iso" "INFO"
+
+    # OPTIMIZED: Single jq+awk pipeline
+    local total_cost
+    total_cost=$(find "$projects_dir" -name "*.jsonl" -type f -mmin -360 2>/dev/null | while read -r jsonl_file; do
+        [[ -z "$jsonl_file" ]] && continue
+        jq -r 'select(.type == "assistant") | select(.message.usage) | select(.timestamp) |
+            [.timestamp, (.message.model // "default"),
+             (.message.usage.input_tokens // 0),
+             (.message.usage.output_tokens // 0),
+             (.message.usage.cache_creation_input_tokens // 0),
+             (.message.usage.cache_read_input_tokens // 0)] | @tsv' "$jsonl_file" 2>/dev/null
+    done | awk -F'\t' -v start="$window_start_iso" '
+    BEGIN {
+        total = 0
+        # Pricing per million tokens
+        p["claude-opus-4-5-20251101"] = "5.00 25.00 6.25 0.50"
+        p["claude-sonnet-4-5-20251101"] = "3.00 15.00 3.75 0.30"
+        p["claude-sonnet-4-20250514"] = "3.00 15.00 3.75 0.30"
+        p["claude-haiku-4-5-20251101"] = "1.00 5.00 1.25 0.10"
+        p["default"] = "5.00 25.00 6.25 0.50"
+    }
+    {
+        ts = $1
+        gsub(/\.[0-9]+Z?$/, "", ts)
+        if (ts < start) next
+
+        model = $2
+        input = $3 + 0
+        output = $4 + 0
+        cache_write = $5 + 0
+        cache_read = $6 + 0
+
+        pricing = p[model]
+        if (pricing == "") pricing = p["default"]
+        split(pricing, pr, " ")
+        cost = (input * pr[1] + output * pr[2] + cache_write * pr[3] + cache_read * pr[4]) / 1000000
+        total += cost
+    }
+    END {
+        printf "%.2f", total
+    }')
+
+    debug_log "API LIVE calculated: \$${total_cost}" "INFO"
+    echo "${total_cost:-0.00}"
+}
+
+# Get API-synced LIVE cost with caching
+get_api_synced_live_cost() {
+    # Check cache first
+    local cache_key="api_synced_live"
+    local cached_result
+    cached_result=$(get_cached_value "$cache_key" "$API_LIVE_CACHE_TTL" 2>/dev/null)
+
+    if [[ -n "$cached_result" ]]; then
+        debug_log "Using cached API-synced LIVE: \$${cached_result}" "INFO"
+        echo "$cached_result"
+        return 0
+    fi
+
+    # Calculate fresh
+    local live_cost
+    live_cost=$(calculate_api_synced_live)
+
+    # Cache result
+    set_cached_value "$cache_key" "$live_cost" 2>/dev/null
+
+    echo "$live_cost"
+}
+
+# ============================================================================
+# EXPORTS
+# ============================================================================
+
+export -f get_model_pricing get_claude_projects_dir calculate_entry_cost
+export -f get_api_window_start calculate_api_synced_live get_api_synced_live_cost
+
+debug_log "API-synced LIVE cost module loaded" "INFO"

--- a/lib/cost/native_calc.sh
+++ b/lib/cost/native_calc.sh
@@ -1,0 +1,399 @@
+#!/bin/bash
+
+# ============================================================================
+# Claude Code Statusline - Native Cost Calculator
+# ============================================================================
+#
+# Unified native cost calculation from JSONL files, eliminating ccusage
+# dependency. Provides time-based filtering for all cost metrics:
+#   - REPO:  Current repository/project cumulative cost
+#   - DAY:   Today's cost (since 00:00 UTC)
+#   - 7DAY:  Last 7 days cost
+#   - 30DAY: Last 30 days cost
+#   - LIVE:  API-synced 5-hour window (uses api_live.sh)
+#
+# Data Source: ~/.claude/projects/ JSONL files
+# Pricing: Inherited from api_live.sh (get_model_pricing)
+#
+# Dependencies: core.sh, api_live.sh (for pricing and base functions)
+# ============================================================================
+
+# Prevent multiple includes
+[[ "${STATUSLINE_COST_NATIVE_CALC_LOADED:-}" == "true" ]] && return 0
+export STATUSLINE_COST_NATIVE_CALC_LOADED=true
+
+# ============================================================================
+# TIME BOUNDARY CALCULATIONS
+# ============================================================================
+
+# Get start of today in ISO format (00:00:00 UTC)
+get_today_start_iso() {
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        date -u "+%Y-%m-%dT00:00:00"
+    else
+        date -u "+%Y-%m-%dT00:00:00"
+    fi
+}
+
+# Get start of N days ago in ISO format
+get_days_ago_start_iso() {
+    local days="${1:-0}"
+
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        date -u -v-${days}d "+%Y-%m-%dT00:00:00"
+    else
+        date -u -d "$days days ago" "+%Y-%m-%dT00:00:00"
+    fi
+}
+
+# ============================================================================
+# JSONL COST CALCULATION
+# ============================================================================
+
+# Calculate total cost from JSONL entries within a time range
+# Args: start_iso [end_iso] [project_filter]
+# If end_iso is empty, uses current time
+# If project_filter is provided, only counts entries from that project
+# OPTIMIZED: Single jq pass with awk for cost calculation (no per-entry jq calls)
+calculate_cost_in_range() {
+    local start_iso="$1"
+    local end_iso="${2:-}"
+    local project_filter="${3:-}"
+
+    local projects_dir
+    projects_dir=$(get_claude_projects_dir)
+
+    if [[ -z "$projects_dir" || ! -d "$projects_dir" ]]; then
+        echo "0.00"
+        return 1
+    fi
+
+    # Find JSONL files (limit to files modified in last 30 days for performance)
+    local find_cmd="find \"$projects_dir\" -name \"*.jsonl\" -type f -mtime -30"
+
+    # If project filter specified, only look in that project directory
+    if [[ -n "$project_filter" ]]; then
+        local sanitized_project
+        sanitized_project=$(echo "$project_filter" | sed 's|/|-|g')
+        find_cmd="find \"$projects_dir\" -path \"*${sanitized_project}*\" -name \"*.jsonl\" -type f"
+    fi
+
+    # OPTIMIZED: Single jq+awk pipeline for all calculations
+    # Output format: timestamp|model|input|output|cache_write|cache_read
+    local total_cost
+    total_cost=$(eval "$find_cmd" 2>/dev/null | while read -r jsonl_file; do
+        [[ -z "$jsonl_file" ]] && continue
+        jq -r 'select(.type == "assistant") | select(.message.usage) | select(.timestamp) |
+            [.timestamp, (.message.model // "default"),
+             (.message.usage.input_tokens // 0),
+             (.message.usage.output_tokens // 0),
+             (.message.usage.cache_creation_input_tokens // 0),
+             (.message.usage.cache_read_input_tokens // 0)] | @tsv' "$jsonl_file" 2>/dev/null
+    done | awk -F'\t' -v start="$start_iso" -v end="$end_iso" '
+    BEGIN {
+        total = 0
+        count = 0
+        # Pricing per million tokens (model -> input output cache_write cache_read)
+        # Opus 4.5
+        p["claude-opus-4-5-20251101"] = "5.00 25.00 6.25 0.50"
+        # Sonnet 4.5 / 4
+        p["claude-sonnet-4-5-20251101"] = "3.00 15.00 3.75 0.30"
+        p["claude-sonnet-4-20250514"] = "3.00 15.00 3.75 0.30"
+        # Haiku 4.5
+        p["claude-haiku-4-5-20251101"] = "1.00 5.00 1.25 0.10"
+        # Default (Opus pricing)
+        p["default"] = "5.00 25.00 6.25 0.50"
+    }
+    {
+        ts = $1
+        # Truncate timestamp for comparison (remove milliseconds and Z)
+        gsub(/\.[0-9]+Z?$/, "", ts)
+
+        # Check time range
+        if (ts < start) next
+        if (end != "" && ts > end) next
+
+        model = $2
+        input = $3 + 0
+        output = $4 + 0
+        cache_write = $5 + 0
+        cache_read = $6 + 0
+
+        # Get pricing for model
+        pricing = p[model]
+        if (pricing == "") pricing = p["default"]
+        split(pricing, pr, " ")
+
+        # Calculate cost (prices per million tokens)
+        cost = (input * pr[1] + output * pr[2] + cache_write * pr[3] + cache_read * pr[4]) / 1000000
+        total += cost
+        count++
+    }
+    END {
+        printf "%.2f", total
+    }')
+
+    debug_log "Native calc ($start_iso to ${end_iso:-now}): \$${total_cost}" "INFO"
+    echo "${total_cost:-0.00}"
+}
+
+# ============================================================================
+# SPECIFIC PERIOD CALCULATIONS
+# ============================================================================
+
+# Calculate today's cost (since 00:00 UTC)
+calculate_native_daily_cost() {
+    local today_start
+    today_start=$(get_today_start_iso)
+    calculate_cost_in_range "$today_start"
+}
+
+# Calculate last 7 days cost
+calculate_native_weekly_cost() {
+    local week_start
+    week_start=$(get_days_ago_start_iso 7)
+    calculate_cost_in_range "$week_start"
+}
+
+# Calculate last 30 days cost
+calculate_native_monthly_cost() {
+    local month_start
+    month_start=$(get_days_ago_start_iso 30)
+    calculate_cost_in_range "$month_start"
+}
+
+# Calculate repository/project cost (all time for current project)
+calculate_native_repo_cost() {
+    local current_dir="${1:-$(pwd)}"
+    # Use a very old date as start to get all entries
+    calculate_cost_in_range "2020-01-01T00:00:00" "" "$current_dir"
+}
+
+# ============================================================================
+# UNIFIED USAGE INFO (ccusage-compatible format)
+# ============================================================================
+
+# Get comprehensive usage info in ccusage-compatible format
+# OPTIMIZED: Single pass through JSONL files, calculates all periods at once
+# Returns: session:month:week:today:block:reset
+get_native_usage_info() {
+    local current_dir="${1:-$(pwd)}"
+
+    debug_log "Calculating native usage info for: $current_dir (single pass)" "INFO"
+
+    local projects_dir
+    projects_dir=$(get_claude_projects_dir)
+
+    if [[ -z "$projects_dir" || ! -d "$projects_dir" ]]; then
+        echo "0.00:0.00:0.00:0.00:No data:"
+        return 1
+    fi
+
+    # Calculate time boundaries
+    local today_start month_start week_start
+    today_start=$(get_today_start_iso)
+    week_start=$(get_days_ago_start_iso 7)
+    month_start=$(get_days_ago_start_iso 30)
+
+    # Sanitize current_dir for project matching
+    local sanitized_project
+    sanitized_project=$(echo "$current_dir" | sed 's|/|-|g')
+
+    # OPTIMIZED: Single jq+awk pass computes ALL periods at once
+    local result
+    result=$(find "$projects_dir" -name "*.jsonl" -type f -mtime -30 2>/dev/null | while read -r jsonl_file; do
+        [[ -z "$jsonl_file" ]] && continue
+        # Include file path for project filtering
+        jq -r --arg file "$jsonl_file" 'select(.type == "assistant") | select(.message.usage) | select(.timestamp) |
+            [$file, .timestamp, (.message.model // "default"),
+             (.message.usage.input_tokens // 0),
+             (.message.usage.output_tokens // 0),
+             (.message.usage.cache_creation_input_tokens // 0),
+             (.message.usage.cache_read_input_tokens // 0)] | @tsv' "$jsonl_file" 2>/dev/null
+    done | awk -F'\t' -v today="$today_start" -v week="$week_start" -v month="$month_start" -v project="$sanitized_project" '
+    BEGIN {
+        daily = 0; weekly = 0; monthly = 0; repo = 0
+        # Pricing per million tokens
+        p["claude-opus-4-5-20251101"] = "5.00 25.00 6.25 0.50"
+        p["claude-sonnet-4-5-20251101"] = "3.00 15.00 3.75 0.30"
+        p["claude-sonnet-4-20250514"] = "3.00 15.00 3.75 0.30"
+        p["claude-haiku-4-5-20251101"] = "1.00 5.00 1.25 0.10"
+        p["default"] = "5.00 25.00 6.25 0.50"
+    }
+    {
+        file = $1
+        ts = $2
+        model = $3
+        input = $4 + 0
+        output = $5 + 0
+        cache_write = $6 + 0
+        cache_read = $7 + 0
+
+        # Truncate timestamp
+        gsub(/\.[0-9]+Z?$/, "", ts)
+
+        # Get pricing
+        pricing = p[model]
+        if (pricing == "") pricing = p["default"]
+        split(pricing, pr, " ")
+        cost = (input * pr[1] + output * pr[2] + cache_write * pr[3] + cache_read * pr[4]) / 1000000
+
+        # Accumulate by period
+        if (ts >= month) monthly += cost
+        if (ts >= week) weekly += cost
+        if (ts >= today) daily += cost
+
+        # Project-specific (repo) cost
+        if (index(file, project) > 0) repo += cost
+    }
+    END {
+        printf "%.2f:%.2f:%.2f:%.2f", repo, monthly, weekly, daily
+    }')
+
+    # Parse result
+    local repo_cost monthly_cost weekly_cost daily_cost
+    IFS=':' read -r repo_cost monthly_cost weekly_cost daily_cost <<< "$result"
+
+    # LIVE block info (from api_live.sh if available)
+    local block_info="No active block"
+    local reset_info=""
+
+    if declare -f get_api_synced_live_cost &>/dev/null; then
+        local live_cost
+        live_cost=$(get_api_synced_live_cost 2>/dev/null)
+        if [[ -n "$live_cost" && "$live_cost" != "0.00" ]]; then
+            block_info="${CONFIG_LIVE_BLOCK_EMOJI:-}${CONFIG_LIVE_LABEL:-LIVE} \$${live_cost}"
+        fi
+    fi
+
+    debug_log "Native usage: repo=\$${repo_cost} month=\$${monthly_cost} week=\$${weekly_cost} day=\$${daily_cost}" "INFO"
+
+    # Format: session:month:week:today:block:reset
+    echo "${repo_cost:-0.00}:${monthly_cost:-0.00}:${weekly_cost:-0.00}:${daily_cost:-0.00}:${block_info}:${reset_info}"
+}
+
+# Cached version of get_native_usage_info
+# Uses file-based cache (5min TTL) for fast repeated calls
+# Processing 1000+ JSONL files takes ~15-20s, so longer TTL is appropriate
+get_cached_native_usage_info() {
+    local current_dir="${1:-$(pwd)}"
+    local cache_ttl="${NATIVE_CALC_CACHE_TTL:-300}"
+
+    # Use project-based cache key (not PID-based)
+    local cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/claude-code-statusline"
+    local sanitized_dir
+    sanitized_dir=$(echo "$current_dir" | sed 's|/|_|g')
+    local cache_file="${cache_dir}/native_usage_${sanitized_dir}.cache"
+
+    # Ensure cache directory exists
+    [[ -d "$cache_dir" ]] || mkdir -p "$cache_dir" 2>/dev/null
+
+    # Return cached if fresh (< cache_ttl seconds, default 5 minutes)
+    if [[ -f "$cache_file" ]]; then
+        local cache_mtime cache_age
+        cache_mtime=$(stat -f "%m" "$cache_file" 2>/dev/null || stat -c "%Y" "$cache_file" 2>/dev/null)
+        cache_age=$(( $(date +%s) - cache_mtime ))
+        if [[ $cache_age -lt $cache_ttl ]]; then
+            debug_log "Using cached native usage info (age=${cache_age}s, ttl=${cache_ttl}s)" "DEBUG"
+            cat "$cache_file"
+            return 0
+        fi
+    fi
+
+    # Calculate fresh and cache
+    local result
+    result=$(get_native_usage_info "$current_dir")
+    echo "$result" > "$cache_file"
+    echo "$result"
+}
+
+# ============================================================================
+# CACHED NATIVE CALCULATIONS
+# ============================================================================
+
+# Cache TTL for native calculations (300 seconds = 5 minutes)
+# Processing 1000+ JSONL files takes ~15-20s, so longer TTL is appropriate
+NATIVE_CALC_CACHE_TTL="${NATIVE_CALC_CACHE_TTL:-300}"
+
+# Get cached daily cost
+get_cached_native_daily_cost() {
+    local cache_key="native_daily_cost"
+    local cached
+    cached=$(get_cached_value "$cache_key" "$NATIVE_CALC_CACHE_TTL" 2>/dev/null)
+
+    if [[ -n "$cached" ]]; then
+        echo "$cached"
+        return 0
+    fi
+
+    local cost
+    cost=$(calculate_native_daily_cost)
+    set_cached_value "$cache_key" "$cost" 2>/dev/null
+    echo "$cost"
+}
+
+# Get cached weekly cost
+get_cached_native_weekly_cost() {
+    local cache_key="native_weekly_cost"
+    local cached
+    cached=$(get_cached_value "$cache_key" "$NATIVE_CALC_CACHE_TTL" 2>/dev/null)
+
+    if [[ -n "$cached" ]]; then
+        echo "$cached"
+        return 0
+    fi
+
+    local cost
+    cost=$(calculate_native_weekly_cost)
+    set_cached_value "$cache_key" "$cost" 2>/dev/null
+    echo "$cost"
+}
+
+# Get cached monthly cost
+get_cached_native_monthly_cost() {
+    local cache_key="native_monthly_cost"
+    local cached
+    cached=$(get_cached_value "$cache_key" "$NATIVE_CALC_CACHE_TTL" 2>/dev/null)
+
+    if [[ -n "$cached" ]]; then
+        echo "$cached"
+        return 0
+    fi
+
+    local cost
+    cost=$(calculate_native_monthly_cost)
+    set_cached_value "$cache_key" "$cost" 2>/dev/null
+    echo "$cost"
+}
+
+# Get cached repo cost
+get_cached_native_repo_cost() {
+    local current_dir="${1:-$(pwd)}"
+    local cache_key="native_repo_cost_$(echo "$current_dir" | sed 's|/|_|g')"
+    local cached
+    cached=$(get_cached_value "$cache_key" "$NATIVE_CALC_CACHE_TTL" 2>/dev/null)
+
+    if [[ -n "$cached" ]]; then
+        echo "$cached"
+        return 0
+    fi
+
+    local cost
+    cost=$(calculate_native_repo_cost "$current_dir")
+    set_cached_value "$cache_key" "$cost" 2>/dev/null
+    echo "$cost"
+}
+
+# ============================================================================
+# EXPORTS
+# ============================================================================
+
+export -f get_today_start_iso get_days_ago_start_iso
+export -f calculate_cost_in_range
+export -f calculate_native_daily_cost calculate_native_weekly_cost
+export -f calculate_native_monthly_cost calculate_native_repo_cost
+export -f get_native_usage_info get_cached_native_usage_info
+export -f get_cached_native_daily_cost get_cached_native_weekly_cost
+export -f get_cached_native_monthly_cost get_cached_native_repo_cost
+
+debug_log "Native cost calculator module loaded" "INFO"


### PR DESCRIPTION
## Summary
Major cost tracking overhaul - native JSONL calculation replacing ccusage dependency with API-synced LIVE cost.

## Key Features
- **Native JSONL Calculation**: All cost metrics (REPO, 30DAY, 7DAY, DAY) now calculated directly from Claude's JSONL files
- **API-Synced LIVE**: LIVE cost aligned with Anthropic OAuth API's 5-hour billing window
- **Optimized Caching**: 5-minute TTL for processing 1000+ JSONL files (0s cached vs 17s fresh)
- **ccusage Optional**: Cost components work without ccusage installed (ccusage becomes fallback)

## Changes
- `lib/cost/api_live.sh` - API-synced LIVE calculation with model pricing lookup
- `lib/cost/native_calc.sh` - Unified native cost calculator for all periods
- `lib/components/cost_*.sh` - Updated to use native calculation (primary)
- `install.sh` - Added new cost modules to installer

## Performance
| Metric | Before | After |
|--------|--------|-------|
| Cost Tracking | 17s | 0s (cached) |
| Cache TTL | 60s | 300s |

## Commits
- `fadd68f` feat(cost): sync LIVE cost with API 5-hour billing window
- `f9fa0e2` feat(cost): decouple from ccusage with native JSONL calculation
- `0de7750` chore(install): add api_live.sh and native_calc.sh to cost modules
- `b179afc` perf(cost): optimize native calculation with 5min cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)