### PR TITLE
fix(prayer_icon): use global declarations for component variables

### DIFF
--- a/lib/components/prayer_icon.sh
+++ b/lib/components/prayer_icon.sh
@@ -20,16 +20,16 @@
 # Include guard
 [[ "${STATUSLINE_PRAYER_ICON_LOADED:-}" == "true" ]] && return 0
 
-# Component data storage
-COMPONENT_PRAYER_ICON_CURRENT=""
-COMPONENT_PRAYER_ICON_INDEX=-1
+# Component data storage (must be global to persist between collect and render phases)
+declare -g COMPONENT_PRAYER_ICON_CURRENT=""
+declare -g COMPONENT_PRAYER_ICON_INDEX=-1
 
 # ============================================================================
 # ICON DEFINITIONS
 # ============================================================================
 
 # Prayer icons (minimalist circles representing sun/moon cycle)
-declare -A PRAYER_ICONS=(
+declare -gA PRAYER_ICONS=(
     [0]="◐"  # Fajr - dawn breaking (half-filled, light side right)
     [1]="●"  # Dhuhr - full sun (solid circle)
     [2]="◑"  # Asr - sun declining (half-filled, light side left)
@@ -38,7 +38,7 @@ declare -A PRAYER_ICONS=(
 )
 
 # Prayer names for debugging
-declare -a PRAYER_NAMES=("Fajr" "Dhuhr" "Asr" "Maghrib" "Isha")
+declare -ga PRAYER_NAMES=("Fajr" "Dhuhr" "Asr" "Maghrib" "Isha")
 
 # ============================================================================
 # COMPONENT DATA COLLECTION
@@ -98,8 +98,9 @@ collect_prayer_icon_data() {
         current_index=$((next_prayer_index - 1))
     fi
 
-    COMPONENT_PRAYER_ICON_INDEX=$current_index
-    COMPONENT_PRAYER_ICON_CURRENT="${PRAYER_NAMES[$current_index]}"
+    # Assign to global variables (must use declare -g to persist across function calls)
+    declare -g COMPONENT_PRAYER_ICON_INDEX=$current_index
+    declare -g COMPONENT_PRAYER_ICON_CURRENT="${PRAYER_NAMES[$current_index]}"
 
     debug_log "Current prayer: $COMPONENT_PRAYER_ICON_CURRENT (index: $current_index)" "INFO"
 


### PR DESCRIPTION
## Summary
Fix prayer_icon component not rendering by using global variable declarations.

## Root Cause
When component files are sourced from within `load_component_modules()` function, variables without `-g` flag become local to that function scope. The variables are set correctly during `collect_all_component_data()` but are lost when the function returns, so `render_prayer_icon()` sees default values (-1).

## Changes
- Add `-g` flag to `COMPONENT_PRAYER_ICON_CURRENT` and `COMPONENT_PRAYER_ICON_INDEX` declarations
- Add `-g` flag to `PRAYER_ICONS` and `PRAYER_NAMES` array declarations
- Use `declare -g` for variable assignments inside `collect_prayer_icon_data()`

## Test
```bash
collect_all_component_data
render_prayer_icon  # Now outputs: ◐
```