### PR TITLE
docs: update Claude Code compatibility to v2.1.22

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Status
 
-**Current**: v2.17.0 | **Claude Code**: v2.1.6–v2.1.19 ✓ | **Branch**: dev → nightly → main
+**Current**: v2.17.0 | **Claude Code**: v2.1.6–v2.1.22 ✓ | **Branch**: dev → nightly → main
 **Architecture**: Single Config.toml (227 settings), modular cache (8 sub-modules), 91.5% code reduction
 **Features**: 7-line statusline, native context % (v2.1.6+), prayer times, cost tracking, MCP, GPS location
 **Platforms**: macOS, Ubuntu, Arch, Fedora, Alpine Linux


### PR DESCRIPTION
## Summary
- Update CLAUDE.md compatibility version from v2.1.19 to v2.1.22
- Verified all 62 native Anthropic tests pass
- Verified all 78 security tests pass
- Verified statusline works with v2.1.22 JSON structure

## Test plan
- [x] Run `bats tests/unit/test_native_anthropic.bats` - 62/62 pass
- [x] Run `bats tests/unit/test_security.bats` - 78/78 pass
- [x] Test with native context_window JSON - works
- [x] Test backward compatibility - works