### PR TITLE
ci: add GitHub Actions GitLab mirror workflow

### DIFF
--- a/.github/workflows/mirror-gitlab.yml
+++ b/.github/workflows/mirror-gitlab.yml
@@ -1,0 +1,27 @@
+name: Mirror to GitLab
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup SSH key
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.GITLAB_SSH_KEY }}
+
+      - name: Mirror to GitLab
+        run: |
+          ssh-keyscan -t ed25519 gitlab.com >> ~/.ssh/known_hosts
+          git remote add gitlab git@gitlab.com:rz1989s/claude-code-statusline.git
+          git push gitlab main --force


### PR DESCRIPTION
Replaces local dual-push with GitHub Actions CI mirror to GitLab. Force-pushes main to GitLab on every commit.