### PR TITLE
feat: Claude Code v2.1.66 compatibility audit + 5 new components

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Status
 
-**Current**: v2.19.0 | **Claude Code**: v2.1.6–v2.1.42 ✓ | **Branch**: feat/fix/chore → nightly → main
-**Architecture**: Single Config.toml (227 settings), modular cache (8 sub-modules), 91.5% code reduction
-**Features**: 9-line statusline, native context % (v2.1.6+), prayer times, cost tracking, MCP, GPS location, wellness, CLI analytics
+**Current**: v2.20.0 | **Claude Code**: v2.1.6–v2.1.66 ✓ | **Branch**: feat/fix/chore → nightly → main
+**Architecture**: Single Config.toml (240+ settings), modular cache (8 sub-modules), JSON abstraction layer
+**Features**: 9-line statusline, native context % (v2.1.6+), prayer times, cost tracking, MCP, GPS location, wellness, CLI analytics, vim mode, agent display
 **Platforms**: macOS, Ubuntu, Arch, Fedora, Alpine Linux
 
 ## Essential Commands
@@ -37,22 +37,26 @@ bats tests/unit/test_platform_compatibility.bats
 
 ## Architecture
 
-**Core Modules** (14): core → security → config → themes → cache → git → mcp → cost → prayer → wellness → focus → components → display
+**Core Modules** (15): core → security → json_fields → config → themes → cache → git → mcp → cost → prayer → wellness → focus → components → display
 
-**Atomic Components** (22):
+**Atomic Components** (27):
 - **Repository & Git** (4): repo_info, commits, submodules, version_info
 - **Model & Session** (4): model_info, cost_repo, cost_live, reset_timer
 - **Cost Analytics** (3): cost_monthly, cost_weekly, cost_daily
 - **Block Metrics** (4): burn_rate, token_usage, cache_efficiency, block_projection
-- **System** (2): mcp_status, time_display
+- **System & Context** (4): mcp_status, time_display, version_display, context_alert
+- **Session State** (2): vim_mode, agent_display
+- **Cumulative Metrics** (1): total_tokens
 - **Wellness** (1): wellness (idle detection, focus mode, break reminders)
 - **Spiritual** (2): prayer_times, location_display
 - **CLI Analytics** (10 commands): --commits, --mcp-costs, --recommendations, --trends, --limits, --watch, --csv, --focus
 
-**Data Flow**: JSON input → Config loading → Theme application → Atomic component data collection → 1-9 line dynamic output (default: 9-line with wellness + GPS location)
+**Data Flow**: JSON input → Schema validation → Config loading → Theme application → Atomic component data collection → 1-9 line dynamic output (default: 9-line with wellness + GPS location)
 
 **Key Functions**:
 - `load_module()` - Module loading with dependency checking
+- `get_json_field()` - Safe JSON extraction with path migration (v2.1.66+)
+- `validate_json_schema()` - Startup schema validation and version detection
 - `load_toml_configuration()` - Single-source TOML parsing
 - `apply_theme()` - Color theme management
 - `execute_cached_command()` - Universal caching with TTL
@@ -129,28 +133,38 @@ ENV_CONFIG_LOCATION_FORMAT=full ./statusline.sh
 
 ## Claude Code JSON Input Format (stdin)
 
-The statusline reads JSON from stdin (`input=$(cat)`), exported as `STATUSLINE_INPUT_JSON` for all components. Only `workspace.current_dir` is required; all other fields are optional with graceful fallbacks.
+The statusline reads JSON from stdin (`input=$(cat)`), exported as `STATUSLINE_INPUT_JSON` for all components. Only `workspace.current_dir` is required; all other fields are optional with graceful fallbacks. Field access uses `get_json_field()` abstraction with automatic path migration for backward compatibility.
 
-**Core Fields** (from Claude Code process):
+**Core Fields** (v2.1.66 schema):
 ```json
 {
-  "workspace": { "current_dir": "/path/to/repo", "project_dir": "/path/to/repo" },
-  "model": { "display_name": "Claude Opus 4.5" },
+  "version": "2.1.66",
+  "cwd": "/path/to/repo",
+  "workspace": { "current_dir": "/path/to/repo", "project_dir": "/path/to/repo", "added_dirs": [] },
+  "model": { "id": "claude-opus-4-6-20250415", "display_name": "Claude Opus 4.6" },
   "session_id": "uuid-string",
   "transcript_path": "/path/to/transcript.jsonl",
   "output_style": { "name": "default" },
-  "context_window": { "used_percentage": 12, "remaining_percentage": 88, "context_window_size": 200000 },
+  "context_window": {
+    "used_percentage": 12, "remaining_percentage": 88, "context_window_size": 200000,
+    "current_usage": { "input_tokens": 10000, "cache_read_input_tokens": 5000, "cache_creation_input_tokens": 2000 },
+    "total_input_tokens": 45000, "total_output_tokens": 12000
+  },
+  "exceeds_200k_tokens": false,
   "cost": { "total_cost_usd": 0.45, "total_duration_ms": 60000, "total_api_duration_ms": 30000, "total_lines_added": 120, "total_lines_removed": 30 },
-  "current_usage": { "input_tokens": 10000, "cache_read_input_tokens": 5000, "cache_creation_input_tokens": 2000 },
-  "five_hour": { "utilization": 15.0, "resets_at": "2026-02-03T19:00:00Z" },
-  "seven_day": { "utilization": 19.0, "resets_at": "2026-02-08T08:00:00Z" },
+  "vim": { "mode": "NORMAL" },
+  "agent": { "name": "security-reviewer" },
   "mcp": { "servers": [] }
 }
 ```
 
-**Manual Test Command** (simulates Claude Code input):
+**Path Migration**: `current_usage.*` moved to `context_window.current_usage.*` in v2.1.66. The `get_json_field()` abstraction handles both paths automatically.
+
+**Usage Limits (OAuth API only)**: `five_hour`/`seven_day` utilization data is NOT provided in the statusline JSON. The `usage_limits` component fetches this from `https://api.anthropic.com/api/oauth/usage` using the OAuth token from macOS Keychain.
+
+**Manual Test Command** (simulates v2.1.66 input):
 ```bash
-echo '{"workspace":{"current_dir":"'$(pwd)'"},"model":{"display_name":"Claude Opus 4.5"},"context_window":{"used_percentage":12},"cost":{"total_cost_usd":0.45,"total_lines_added":120,"total_lines_removed":30},"current_usage":{"cache_read_input_tokens":5000,"input_tokens":10000},"session_id":"test","mcp":{"servers":[]}}' | /opt/homebrew/bin/bash ~/.claude/statusline/statusline.sh
+echo '{"version":"2.1.66","workspace":{"current_dir":"'$(pwd)'"},"model":{"id":"claude-opus-4-6-20250415","display_name":"Claude Opus 4.6"},"context_window":{"used_percentage":12,"current_usage":{"cache_read_input_tokens":5000,"input_tokens":10000},"total_input_tokens":45000,"total_output_tokens":12000},"cost":{"total_cost_usd":0.45,"total_lines_added":120,"total_lines_removed":30},"session_id":"test","mcp":{"servers":[]}}' | /opt/homebrew/bin/bash ~/.claude/statusline/statusline.sh
 ```
 
 **macOS Note**: Requires bash 4+ (`brew install bash`). Settings.json should use `/opt/homebrew/bin/bash` (Apple Silicon) or `/usr/local/bin/bash` (Intel) instead of `bash`.

--- a/docs/plans/2026-03-04-v2166-compatibility-audit-design.md
+++ b/docs/plans/2026-03-04-v2166-compatibility-audit-design.md
@@ -1,0 +1,221 @@
+# v2.1.66 Compatibility Audit + Future-Proof Architecture
+
+**Date**: 2026-03-04
+**Version**: v2.20.0
+**Branch**: feat/v2166-compat
+**Scope**: Full audit, new JSON abstraction layer, 5 new components, OAuth hardening, path migration
+
+## Problem Statement
+
+Claude Code v2.1.66 introduced schema changes and new fields not handled by the statusline:
+1. `five_hour`/`seven_day` usage data is NOT in the official statusline JSON schema - OAuth API is the only source
+2. `current_usage` path moved from top-level to `context_window.current_usage`
+3. New fields available: `version`, `model.id`, `exceeds_200k_tokens`, `vim.mode`, `agent.name`, cumulative token counts, `workspace.added_dirs`
+4. OAuth API fails silently with no error visibility
+5. Tested version range outdated (v2.1.42)
+
+## Architecture
+
+### 1. JSON Field Access Abstraction Layer
+
+New module: `lib/json_fields.sh`
+
+**Functions:**
+- `get_json_field(path, [default])` - Safe extraction with path migration. Tries canonical path first, then legacy fallback.
+- `has_json_field(path)` - Boolean existence check
+- `validate_json_schema()` - Startup validation, detect Claude Code version, log missing optional fields
+- `get_detected_cc_version()` - Returns detected Claude Code version from `.version` field
+
+**Path Migration Map:**
+```
+current_usage.input_tokens        -> context_window.current_usage.input_tokens
+current_usage.output_tokens       -> context_window.current_usage.output_tokens
+current_usage.cache_read_input_tokens    -> context_window.current_usage.cache_read_input_tokens
+current_usage.cache_creation_input_tokens -> context_window.current_usage.cache_creation_input_tokens
+```
+
+**Schema Compatibility Matrix:**
+```
+model.id                              v2.1.6+
+model.display_name                    v2.1.0+
+version                               v2.1.50+
+cwd                                   v2.1.0+
+workspace.current_dir                 v2.1.0+
+workspace.project_dir                 v2.1.0+
+workspace.added_dirs                  v2.1.63+
+context_window.used_percentage        v2.1.6+
+context_window.remaining_percentage   v2.1.6+
+context_window.context_window_size    v2.1.6+
+context_window.current_usage          v2.1.50+
+context_window.total_input_tokens     v2.1.50+
+context_window.total_output_tokens    v2.1.50+
+current_usage (top-level)             v2.1.6+ (deprecated, migrated to context_window.current_usage)
+cost.total_cost_usd                   v2.1.0+
+cost.total_duration_ms                v2.1.0+
+cost.total_api_duration_ms            v2.1.0+
+cost.total_lines_added                v2.1.0+
+cost.total_lines_removed              v2.1.0+
+exceeds_200k_tokens                   v2.1.50+
+session_id                            v2.1.0+
+transcript_path                       v2.1.0+
+output_style.name                     v2.1.0+
+vim.mode                              v2.1.50+ (only when vim mode enabled)
+agent.name                            v2.1.50+ (only with --agent flag)
+mcp.servers                           undocumented (present in practice)
+five_hour/seven_day                   NOT in statusline JSON (OAuth API only)
+```
+
+**Module Loading Order:**
+`json_fields` loads AFTER `security` and BEFORE `config` (needs early access to JSON).
+
+### 2. OAuth API Hardening
+
+File: `lib/components/usage_limits.sh`
+
+**Changes to `fetch_usage_limits()`:**
+- Capture HTTP status code: `curl -s -w "\n%{http_code}" --max-time 5`
+- Parse response body and status separately
+- Error handling per status code:
+  - 200: Parse and cache response
+  - 401: Log "OAuth token expired/invalid - re-authenticate Claude Code"
+  - 403: Log "OAuth access forbidden"
+  - 429: Log "Rate limited - using cached data"
+  - 5xx: Single retry after 2s, then "API unavailable"
+  - Timeout: Log "API timeout (5s)"
+  - Connection error: Log "Cannot reach API"
+- Show "Limit: --" instead of blank line when data unavailable
+- Add `COMPONENT_USAGE_STATUS` variable for error state communication
+
+### 3. Five New Atomic Components
+
+#### 3.1 `version_display` (`lib/components/version_display.sh`)
+- **Source**: `get_json_field "version"`
+- **Format**: `v2.1.66` (short) or `CC v2.1.66` (full, configurable)
+- **Color**: Teal (informational, distinct from model)
+- **Config**: `features.show_version_display = true`, `version_display.format = "short"`
+- **Default Line**: 2 (after model_info)
+- **Fallback**: Hidden when field absent (pre-v2.1.50)
+
+#### 3.2 `vim_mode` (`lib/components/vim_mode.sh`)
+- **Source**: `get_json_field "vim.mode"`
+- **Format**: `VIM:NORMAL` (green) / `VIM:INSERT` (yellow)
+- **Config**: `features.show_vim_mode = true`
+- **Default Line**: 8 (with session_mode)
+- **Fallback**: Hidden when vim mode not enabled (field absent)
+
+#### 3.3 `agent_display` (`lib/components/agent_display.sh`)
+- **Source**: `get_json_field "agent.name"`
+- **Format**: `Agent: security-reviewer`
+- **Color**: Purple (distinguishes from other metadata)
+- **Config**: `features.show_agent_display = true`
+- **Default Line**: 8 (with session_mode)
+- **Fallback**: Hidden when not in agent mode (field absent)
+
+#### 3.4 `context_alert` (`lib/components/context_alert.sh`)
+- **Source**: `get_json_field "exceeds_200k_tokens"`
+- **Format**: `>200K` (red, bold) - only shows when true
+- **Config**: `features.show_context_alert = true`, `context_alert.show_only_when_exceeded = true`
+- **Default Line**: 4 (adjacent to context_window)
+- **Fallback**: Hidden when false or field absent
+
+#### 3.5 `total_tokens` (`lib/components/total_tokens.sh`)
+- **Source**: `get_json_field "context_window.total_input_tokens"` + `get_json_field "context_window.total_output_tokens"`
+- **Format**: `Tokens: 15.2K in / 4.5K out` or compact `19.7K total`
+- **Color**: Blue (matches token_usage theme)
+- **Config**: `features.show_total_tokens = true`, `total_tokens.format = "split"` (split/compact)
+- **Default Line**: 4 (with block metrics)
+- **Fallback**: Hidden when fields absent
+
+### 4. Config.toml Updates
+
+New entries in `examples/Config.toml`:
+```toml
+# === v2.20.0 NEW COMPONENTS ===
+features.show_version_display = true
+features.show_vim_mode = true
+features.show_agent_display = true
+features.show_context_alert = true
+features.show_total_tokens = true
+
+version_display.format = "short"
+total_tokens.format = "split"
+context_alert.show_only_when_exceeded = true
+context_alert.threshold_label = ">200K"
+
+# Updated default lines
+display.line2.components = ["model_info", "version_display", "commits", "submodules", "version_info", "time_display"]
+display.line4.components = ["burn_rate", "cache_efficiency", "block_projection", "total_tokens", "context_alert", "context_window"]
+display.line8.components = ["mcp_status", "session_mode", "vim_mode", "agent_display"]
+```
+
+### 5. Module Refactoring
+
+All 6 modules that directly access `STATUSLINE_INPUT_JSON` via jq will be refactored to use `get_json_field()`:
+
+| Module | Fields Accessed | Migration Needed |
+|--------|----------------|------------------|
+| `lib/cost/native.sh` | `.current_usage.*`, `.cost.*` | YES - current_usage path |
+| `lib/cost/session.sh` | `.context_window.*`, `.transcript_path`, `.session_id`, `.workspace.*` | NO - paths correct |
+| `lib/cost/recommendations.sh` | `.current_usage.*` | YES - current_usage path |
+| `lib/cost/api_live.sh` | `.five_hour.resets_at` | NO - OAuth-only field, skip abstraction |
+| `lib/cli/reports.sh` | Multiple fields | PARTIAL - add get_json_field for new fields |
+| `lib/mcp.sh` | `.mcp.servers` | NO - undocumented but working |
+
+### 6. Documentation Updates
+
+**CLAUDE.md:**
+- Update JSON schema to match official v2.1.66 docs
+- Update tested version: `v2.1.6-v2.1.66`
+- Add new components (22 -> 27) to architecture
+- Add JSON field access layer to key functions
+- Add migration notes
+
+### 7. Test Coverage
+
+| Test File | Tests | Priority |
+|-----------|-------|----------|
+| `tests/unit/test_json_fields.bats` | get_json_field, has_json_field, path migration, schema validation, version detection | HIGH |
+| `tests/unit/test_oauth_usage.bats` | Token retrieval, API responses (200/401/403/429/5xx), retry, cache, timeout | HIGH |
+| `tests/unit/test_version_display.bats` | Collect/render with version present/absent, format options | MEDIUM |
+| `tests/unit/test_vim_mode.bats` | NORMAL/INSERT rendering, absent field handling | MEDIUM |
+| `tests/unit/test_agent_display.bats` | Agent present/absent, rendering | MEDIUM |
+| `tests/unit/test_context_alert.bats` | Exceeded true/false/absent, conditional display | MEDIUM |
+| `tests/unit/test_total_tokens.bats` | Split/compact format, zero/null handling | MEDIUM |
+
+## Files Summary
+
+**New (13):**
+- `lib/json_fields.sh`
+- `lib/components/version_display.sh`
+- `lib/components/vim_mode.sh`
+- `lib/components/agent_display.sh`
+- `lib/components/context_alert.sh`
+- `lib/components/total_tokens.sh`
+- `tests/unit/test_json_fields.bats`
+- `tests/unit/test_oauth_usage.bats`
+- `tests/unit/test_version_display.bats`
+- `tests/unit/test_vim_mode.bats`
+- `tests/unit/test_agent_display.bats`
+- `tests/unit/test_context_alert.bats`
+- `tests/unit/test_total_tokens.bats`
+
+**Modified (10):**
+- `statusline.sh` (load json_fields, schema validation)
+- `lib/cost/native.sh` (use get_json_field for current_usage)
+- `lib/cost/session.sh` (use get_json_field)
+- `lib/cost/recommendations.sh` (use get_json_field for current_usage)
+- `lib/cli/reports.sh` (use get_json_field, add new field extraction)
+- `lib/components/usage_limits.sh` (OAuth hardening)
+- `examples/Config.toml` (new components + updated lines)
+- `CLAUDE.md` (schema, version, architecture)
+- `lib/components.sh` (register new components in load order)
+- `lib/display.sh` (handle new components in rendering)
+
+**Total: 23 files (13 new + 10 modified)**
+
+## Compatibility
+
+- Backward compatible with v2.1.6+ (path migration handles both old and new JSON)
+- New components gracefully hidden when fields absent
+- OAuth API fallback preserved for limit data
+- No breaking changes to existing configuration

--- a/docs/plans/2026-03-04-v2166-compatibility-audit.md
+++ b/docs/plans/2026-03-04-v2166-compatibility-audit.md
@@ -1,0 +1,1806 @@
+# v2.1.66 Compatibility Audit Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Full v2.1.66 compatibility — JSON abstraction layer, 5 new components, OAuth hardening, path migration, updated docs.
+
+**Architecture:** New `lib/json_fields.sh` module provides `get_json_field()` with path migration (tries canonical v2.1.66 path first, then legacy fallback). All JSON access goes through this layer. Five new atomic components follow existing pattern (collect/render/config + register_component). OAuth API gets HTTP status code handling and retry logic.
+
+**Tech Stack:** Bash 4+, jq, BATS testing, TOML config
+
+---
+
+### Task 1: Create JSON Field Access Layer — Tests
+
+**Files:**
+- Create: `tests/unit/test_json_fields.bats`
+
+**Step 1: Write the failing tests**
+
+```bash
+#!/usr/bin/env bats
+# ==============================================================================
+# Test: JSON Field Access Abstraction Layer
+# ==============================================================================
+
+load "../setup_suite"
+
+setup() {
+    common_setup
+    STATUSLINE_TESTING="true"
+    export STATUSLINE_TESTING
+    # Source the module
+    export STATUSLINE_SOURCING=true
+    source "$STATUSLINE_ROOT/lib/core.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/json_fields.sh" 2>/dev/null || true
+}
+
+teardown() {
+    common_teardown
+}
+
+# ==============================================================================
+# get_json_field basic extraction
+# ==============================================================================
+
+@test "get_json_field extracts simple top-level field" {
+    export STATUSLINE_INPUT_JSON='{"version":"2.1.66"}'
+    run get_json_field "version"
+    assert_success
+    assert_output "2.1.66"
+}
+
+@test "get_json_field extracts nested field with dot notation" {
+    export STATUSLINE_INPUT_JSON='{"model":{"display_name":"Opus","id":"claude-opus-4-6"}}'
+    run get_json_field "model.display_name"
+    assert_success
+    assert_output "Opus"
+}
+
+@test "get_json_field returns default when field missing" {
+    export STATUSLINE_INPUT_JSON='{"model":{"display_name":"Opus"}}'
+    run get_json_field "version" "unknown"
+    assert_success
+    assert_output "unknown"
+}
+
+@test "get_json_field returns empty string when field missing and no default" {
+    export STATUSLINE_INPUT_JSON='{"model":{"display_name":"Opus"}}'
+    run get_json_field "nonexistent"
+    assert_success
+    assert_output ""
+}
+
+@test "get_json_field handles null JSON values" {
+    export STATUSLINE_INPUT_JSON='{"version":null}'
+    run get_json_field "version" "fallback"
+    assert_success
+    assert_output "fallback"
+}
+
+@test "get_json_field handles empty STATUSLINE_INPUT_JSON" {
+    export STATUSLINE_INPUT_JSON=""
+    run get_json_field "version" "none"
+    assert_success
+    assert_output "none"
+}
+
+# ==============================================================================
+# Path migration: current_usage -> context_window.current_usage
+# ==============================================================================
+
+@test "get_json_field migrates current_usage to context_window.current_usage (new path)" {
+    export STATUSLINE_INPUT_JSON='{"context_window":{"current_usage":{"input_tokens":8500}}}'
+    run get_json_field "current_usage.input_tokens"
+    assert_success
+    assert_output "8500"
+}
+
+@test "get_json_field falls back to legacy current_usage path" {
+    export STATUSLINE_INPUT_JSON='{"current_usage":{"input_tokens":7000}}'
+    run get_json_field "current_usage.input_tokens"
+    assert_success
+    assert_output "7000"
+}
+
+@test "get_json_field prefers new path over legacy" {
+    export STATUSLINE_INPUT_JSON='{"context_window":{"current_usage":{"input_tokens":9000}},"current_usage":{"input_tokens":5000}}'
+    run get_json_field "current_usage.input_tokens"
+    assert_success
+    assert_output "9000"
+}
+
+@test "get_json_field migrates cache_read_input_tokens" {
+    export STATUSLINE_INPUT_JSON='{"context_window":{"current_usage":{"cache_read_input_tokens":3000}}}'
+    run get_json_field "current_usage.cache_read_input_tokens"
+    assert_success
+    assert_output "3000"
+}
+
+@test "get_json_field migrates cache_creation_input_tokens" {
+    export STATUSLINE_INPUT_JSON='{"context_window":{"current_usage":{"cache_creation_input_tokens":2000}}}'
+    run get_json_field "current_usage.cache_creation_input_tokens"
+    assert_success
+    assert_output "2000"
+}
+
+# ==============================================================================
+# has_json_field
+# ==============================================================================
+
+@test "has_json_field returns 0 when field exists" {
+    export STATUSLINE_INPUT_JSON='{"version":"2.1.66"}'
+    run has_json_field "version"
+    assert_success
+}
+
+@test "has_json_field returns 1 when field missing" {
+    export STATUSLINE_INPUT_JSON='{"model":{"display_name":"Opus"}}'
+    run has_json_field "version"
+    assert_failure
+}
+
+@test "has_json_field returns 1 for null field" {
+    export STATUSLINE_INPUT_JSON='{"version":null}'
+    run has_json_field "version"
+    assert_failure
+}
+
+@test "has_json_field detects nested fields" {
+    export STATUSLINE_INPUT_JSON='{"vim":{"mode":"NORMAL"}}'
+    run has_json_field "vim.mode"
+    assert_success
+}
+
+# ==============================================================================
+# validate_json_schema
+# ==============================================================================
+
+@test "validate_json_schema detects Claude Code version" {
+    export STATUSLINE_INPUT_JSON='{"version":"2.1.66","workspace":{"current_dir":"/tmp"}}'
+    validate_json_schema
+    run get_detected_cc_version
+    assert_success
+    assert_output "2.1.66"
+}
+
+@test "validate_json_schema returns unknown for missing version" {
+    export STATUSLINE_INPUT_JSON='{"workspace":{"current_dir":"/tmp"}}'
+    validate_json_schema
+    run get_detected_cc_version
+    assert_success
+    assert_output "unknown"
+}
+
+# ==============================================================================
+# Boolean field extraction
+# ==============================================================================
+
+@test "get_json_field_bool returns true for true boolean" {
+    export STATUSLINE_INPUT_JSON='{"exceeds_200k_tokens":true}'
+    run get_json_field_bool "exceeds_200k_tokens"
+    assert_success
+    assert_output "true"
+}
+
+@test "get_json_field_bool returns false for false boolean" {
+    export STATUSLINE_INPUT_JSON='{"exceeds_200k_tokens":false}'
+    run get_json_field_bool "exceeds_200k_tokens"
+    assert_success
+    assert_output "false"
+}
+
+@test "get_json_field_bool returns default for missing field" {
+    export STATUSLINE_INPUT_JSON='{"version":"2.1.66"}'
+    run get_json_field_bool "exceeds_200k_tokens" "false"
+    assert_success
+    assert_output "false"
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `bats tests/unit/test_json_fields.bats`
+Expected: FAIL — `lib/json_fields.sh` does not exist
+
+**Step 3: Commit test file**
+
+```bash
+git add tests/unit/test_json_fields.bats
+git commit -m "test: add JSON field access layer tests for v2.1.66 compat"
+```
+
+---
+
+### Task 2: Create JSON Field Access Layer — Implementation
+
+**Files:**
+- Create: `lib/json_fields.sh`
+
+**Step 1: Implement the module**
+
+```bash
+#!/bin/bash
+
+# ============================================================================
+# Claude Code Statusline - JSON Field Access Abstraction Layer
+# ============================================================================
+#
+# Provides safe, version-aware JSON field extraction from STATUSLINE_INPUT_JSON.
+# Handles path migration (e.g., current_usage -> context_window.current_usage)
+# and schema validation for Claude Code v2.1.6 through v2.1.66+.
+#
+# Dependencies: core.sh (debug_log)
+# Load order: AFTER security, BEFORE config
+# ============================================================================
+
+# Prevent multiple includes
+[[ "${STATUSLINE_JSON_FIELDS_LOADED:-}" == "true" ]] && return 0
+export STATUSLINE_JSON_FIELDS_LOADED=true
+
+# Detected Claude Code version (set by validate_json_schema)
+_DETECTED_CC_VERSION="unknown"
+
+# ============================================================================
+# PATH MIGRATION MAP
+# ============================================================================
+# Maps legacy field paths to their new canonical paths in v2.1.66+
+# Format: "legacy_prefix:canonical_prefix"
+
+_JSON_MIGRATION_PATHS=(
+    "current_usage:context_window.current_usage"
+)
+
+# ============================================================================
+# CORE FIELD EXTRACTION
+# ============================================================================
+
+# Extract a field from STATUSLINE_INPUT_JSON with path migration support
+# Args: field_path [default_value]
+# Returns: field value, default_value if missing, or empty string
+get_json_field() {
+    local field_path="$1"
+    local default_value="${2:-}"
+
+    if [[ -z "${STATUSLINE_INPUT_JSON:-}" ]]; then
+        echo "$default_value"
+        return 0
+    fi
+
+    local result=""
+
+    # Check if this path needs migration
+    local migrated=false
+    for mapping in "${_JSON_MIGRATION_PATHS[@]}"; do
+        local legacy_prefix="${mapping%%:*}"
+        local canonical_prefix="${mapping##*:}"
+
+        if [[ "$field_path" == "$legacy_prefix"* ]]; then
+            # Build canonical path
+            local suffix="${field_path#"$legacy_prefix"}"
+            local canonical_path="${canonical_prefix}${suffix}"
+
+            # Try canonical path first (new v2.1.66+ location)
+            result=$(echo "$STATUSLINE_INPUT_JSON" | jq -r ".${canonical_path} // empty" 2>/dev/null)
+            if [[ -n "$result" && "$result" != "null" ]]; then
+                migrated=true
+                break
+            fi
+
+            # Fall back to legacy path
+            result=$(echo "$STATUSLINE_INPUT_JSON" | jq -r ".${field_path} // empty" 2>/dev/null)
+            if [[ -n "$result" && "$result" != "null" ]]; then
+                migrated=true
+                break
+            fi
+        fi
+    done
+
+    # No migration needed — direct extraction
+    if [[ "$migrated" == "false" ]]; then
+        result=$(echo "$STATUSLINE_INPUT_JSON" | jq -r ".${field_path} // empty" 2>/dev/null)
+    fi
+
+    # Return result or default
+    if [[ -n "$result" && "$result" != "null" ]]; then
+        echo "$result"
+    else
+        echo "$default_value"
+    fi
+}
+
+# Check if a JSON field exists and is not null
+# Args: field_path
+# Returns: 0 if exists, 1 if missing/null
+has_json_field() {
+    local field_path="$1"
+
+    if [[ -z "${STATUSLINE_INPUT_JSON:-}" ]]; then
+        return 1
+    fi
+
+    # Check with migration support
+    local result
+    result=$(get_json_field "$field_path")
+
+    if [[ -n "$result" ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Extract a boolean field (returns "true" or "false")
+# Args: field_path [default_value]
+get_json_field_bool() {
+    local field_path="$1"
+    local default_value="${2:-false}"
+
+    if [[ -z "${STATUSLINE_INPUT_JSON:-}" ]]; then
+        echo "$default_value"
+        return 0
+    fi
+
+    local result
+    result=$(echo "$STATUSLINE_INPUT_JSON" | jq -r "if .${field_path} == true then \"true\" elif .${field_path} == false then \"false\" else empty end" 2>/dev/null)
+
+    if [[ -n "$result" ]]; then
+        echo "$result"
+    else
+        echo "$default_value"
+    fi
+}
+
+# Extract a numeric field with default
+# Args: field_path [default_value]
+get_json_field_num() {
+    local field_path="$1"
+    local default_value="${2:-0}"
+
+    local result
+    result=$(get_json_field "$field_path" "$default_value")
+
+    # Validate it's numeric
+    if [[ "$result" =~ ^-?[0-9]+\.?[0-9]*$ ]]; then
+        echo "$result"
+    else
+        echo "$default_value"
+    fi
+}
+
+# ============================================================================
+# SCHEMA VALIDATION
+# ============================================================================
+
+# Validate JSON schema and detect Claude Code version
+# Called once after JSON is loaded in statusline.sh
+validate_json_schema() {
+    if [[ -z "${STATUSLINE_INPUT_JSON:-}" ]]; then
+        debug_log "No JSON input to validate" "WARN"
+        _DETECTED_CC_VERSION="unknown"
+        return 0
+    fi
+
+    # Detect Claude Code version
+    local version
+    version=$(echo "$STATUSLINE_INPUT_JSON" | jq -r '.version // empty' 2>/dev/null)
+    if [[ -n "$version" && "$version" != "null" ]]; then
+        _DETECTED_CC_VERSION="$version"
+        debug_log "Detected Claude Code version: $version" "INFO"
+    else
+        _DETECTED_CC_VERSION="unknown"
+        debug_log "Claude Code version not available in JSON (pre-v2.1.50)" "INFO"
+    fi
+
+    # Check required field
+    local current_dir
+    current_dir=$(echo "$STATUSLINE_INPUT_JSON" | jq -r '.workspace.current_dir // empty' 2>/dev/null)
+    if [[ -z "$current_dir" ]]; then
+        debug_log "Required field missing: workspace.current_dir" "WARN"
+    fi
+
+    # Log available optional fields for debugging
+    local available_fields=""
+    has_json_field "version" && available_fields+="version "
+    has_json_field "model.id" && available_fields+="model.id "
+    has_json_field "exceeds_200k_tokens" && available_fields+="exceeds_200k "
+    has_json_field "vim.mode" && available_fields+="vim.mode "
+    has_json_field "agent.name" && available_fields+="agent.name "
+    has_json_field "context_window.total_input_tokens" && available_fields+="total_tokens "
+    has_json_field "workspace.added_dirs" && available_fields+="added_dirs "
+
+    if [[ -n "$available_fields" ]]; then
+        debug_log "Available v2.1.66 fields: $available_fields" "INFO"
+    fi
+
+    return 0
+}
+
+# Get detected Claude Code version
+get_detected_cc_version() {
+    echo "$_DETECTED_CC_VERSION"
+}
+
+# ============================================================================
+# EXPORTS
+# ============================================================================
+
+export -f get_json_field has_json_field get_json_field_bool get_json_field_num
+export -f validate_json_schema get_detected_cc_version
+
+debug_log "JSON fields abstraction layer loaded" "INFO"
+```
+
+**Step 2: Run tests to verify they pass**
+
+Run: `bats tests/unit/test_json_fields.bats`
+Expected: All tests PASS
+
+**Step 3: Commit**
+
+```bash
+git add lib/json_fields.sh
+git commit -m "feat: add JSON field access abstraction layer for v2.1.66 compat"
+```
+
+---
+
+### Task 3: Integrate json_fields into statusline.sh
+
+**Files:**
+- Modify: `statusline.sh:99` (module loading section, after security, before config)
+- Modify: `statusline.sh:1345` (after JSON export, add schema validation)
+
+**Step 1: Add module loading**
+
+After line 99 (`load_module "security"`), add:
+
+```bash
+load_module "json_fields" || {
+    debug_log "Failed to load JSON fields module" "WARN"
+}
+```
+
+**Step 2: Add schema validation after JSON export**
+
+After line 1345 (`export STATUSLINE_INPUT_JSON="$input"`), add:
+
+```bash
+# Validate JSON schema and detect Claude Code version
+if is_module_loaded "json_fields"; then
+    validate_json_schema
+fi
+```
+
+**Step 3: Run existing test suite**
+
+Run: `npm test`
+Expected: All existing 838+ tests PASS (no regressions)
+
+**Step 4: Commit**
+
+```bash
+git add statusline.sh
+git commit -m "feat: integrate JSON fields module into statusline boot sequence"
+```
+
+---
+
+### Task 4: Migrate native.sh to use get_json_field
+
+**Files:**
+- Modify: `lib/cost/native.sh:99,111` (current_usage extractions)
+
+**Step 1: Replace direct jq calls with get_json_field**
+
+In `get_native_cache_read_tokens()` (line 99), replace:
+```bash
+tokens=$(echo "$STATUSLINE_INPUT_JSON" | jq -r '.current_usage.cache_read_input_tokens // 0' 2>/dev/null)
+```
+With:
+```bash
+tokens=$(get_json_field "current_usage.cache_read_input_tokens" "0")
+```
+
+In `get_native_cache_creation_tokens()` (line 111), replace:
+```bash
+tokens=$(echo "$STATUSLINE_INPUT_JSON" | jq -r '.current_usage.cache_creation_input_tokens // 0' 2>/dev/null)
+```
+With:
+```bash
+tokens=$(get_json_field "current_usage.cache_creation_input_tokens" "0")
+```
+
+**Step 2: Run tests**
+
+Run: `npm test`
+Expected: All tests PASS
+
+**Step 3: Commit**
+
+```bash
+git add lib/cost/native.sh
+git commit -m "refactor: migrate native.sh to use get_json_field for current_usage path compat"
+```
+
+---
+
+### Task 5: Migrate recommendations.sh to use get_json_field
+
+**Files:**
+- Modify: `lib/cost/recommendations.sh:363-364`
+
+**Step 1: Replace direct jq calls**
+
+At line 363-364, replace:
+```bash
+cache_read=$(echo "$STATUSLINE_INPUT_JSON" | jq -r '.current_usage.cache_read_input_tokens // 0' 2>/dev/null) || cache_read=0
+input_tokens=$(echo "$STATUSLINE_INPUT_JSON" | jq -r '.current_usage.input_tokens // 0' 2>/dev/null) || input_tokens=0
+```
+With:
+```bash
+cache_read=$(get_json_field "current_usage.cache_read_input_tokens" "0") || cache_read=0
+input_tokens=$(get_json_field "current_usage.input_tokens" "0") || input_tokens=0
+```
+
+**Step 2: Run tests**
+
+Run: `npm test`
+Expected: All tests PASS
+
+**Step 3: Commit**
+
+```bash
+git add lib/cost/recommendations.sh
+git commit -m "refactor: migrate recommendations.sh to use get_json_field for current_usage path compat"
+```
+
+---
+
+### Task 6: Harden OAuth API — Tests
+
+**Files:**
+- Create: `tests/unit/test_oauth_usage.bats`
+
+**Step 1: Write failing tests**
+
+```bash
+#!/usr/bin/env bats
+# ==============================================================================
+# Test: OAuth Usage Limits API Hardening
+# ==============================================================================
+
+load "../setup_suite"
+
+setup() {
+    common_setup
+    STATUSLINE_TESTING="true"
+    export STATUSLINE_TESTING
+    export STATUSLINE_SOURCING=true
+    source "$STATUSLINE_ROOT/lib/core.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/security.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/cache.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/json_fields.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/components.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/components/usage_limits.sh" 2>/dev/null || true
+}
+
+teardown() {
+    common_teardown
+}
+
+# ==============================================================================
+# Native JSON priority (when five_hour/seven_day present)
+# ==============================================================================
+
+@test "collect_usage_limits_data uses native JSON when five_hour.utilization present" {
+    export STATUSLINE_INPUT_JSON='{"five_hour":{"utilization":22.5,"resets_at":"2026-03-04T19:00:00Z"},"seven_day":{"utilization":54.0,"resets_at":"2026-03-08T08:00:00Z"}}'
+    collect_usage_limits_data
+    [[ "$COMPONENT_USAGE_FIVE_HOUR" == "23" || "$COMPONENT_USAGE_FIVE_HOUR" == "22" ]]
+}
+
+@test "collect_usage_limits_data sets empty when no data available" {
+    export STATUSLINE_INPUT_JSON='{"workspace":{"current_dir":"/tmp"}}'
+    # Mock curl to fail
+    create_failing_mock_command "curl" "Connection refused"
+    # Mock security to fail
+    create_failing_mock_command "security" "SecItemNotFound"
+    collect_usage_limits_data
+    [[ -z "$COMPONENT_USAGE_FIVE_HOUR" ]]
+}
+
+# ==============================================================================
+# Usage reset rendering
+# ==============================================================================
+
+@test "render_usage_reset shows countdown when data available" {
+    export STATUSLINE_INPUT_JSON='{"five_hour":{"utilization":22.5,"resets_at":"2026-03-04T23:00:00Z"},"seven_day":{"utilization":54.0,"resets_at":"2026-03-08T08:00:00Z"}}'
+    collect_usage_limits_data
+    run render_usage_reset "false"
+    assert_success
+    assert_output --partial "5H"
+}
+
+@test "render_usage_reset returns 1 when no data" {
+    COMPONENT_USAGE_FIVE_HOUR=""
+    COMPONENT_USAGE_SEVEN_DAY=""
+    run render_usage_reset "false"
+    assert_failure
+}
+
+# ==============================================================================
+# Error status communication
+# ==============================================================================
+
+@test "COMPONENT_USAGE_STATUS is set to ok on success" {
+    export STATUSLINE_INPUT_JSON='{"five_hour":{"utilization":22.5,"resets_at":"2026-03-04T19:00:00Z"}}'
+    collect_usage_limits_data
+    [[ "$COMPONENT_USAGE_STATUS" == "ok" ]]
+}
+
+@test "COMPONENT_USAGE_STATUS is set to unavailable on failure" {
+    export STATUSLINE_INPUT_JSON='{"workspace":{"current_dir":"/tmp"}}'
+    create_failing_mock_command "curl" "Connection refused"
+    create_failing_mock_command "security" "SecItemNotFound"
+    collect_usage_limits_data
+    [[ "$COMPONENT_USAGE_STATUS" == "unavailable" ]]
+}
+```
+
+**Step 2: Run to verify fails**
+
+Run: `bats tests/unit/test_oauth_usage.bats`
+Expected: Some tests FAIL (COMPONENT_USAGE_STATUS not defined yet)
+
+**Step 3: Commit**
+
+```bash
+git add tests/unit/test_oauth_usage.bats
+git commit -m "test: add OAuth usage limits API hardening tests"
+```
+
+---
+
+### Task 7: Harden OAuth API — Implementation
+
+**Files:**
+- Modify: `lib/components/usage_limits.sh:19-22,294-393`
+
+**Step 1: Add status variable (after line 22)**
+
+```bash
+COMPONENT_USAGE_STATUS="unknown"
+```
+
+**Step 2: Rewrite `fetch_usage_limits()` with HTTP status handling**
+
+Replace the function (lines 294-335) with:
+
+```bash
+fetch_usage_limits() {
+    local token
+    token=$(get_claude_oauth_token)
+
+    if [[ -z "$token" ]]; then
+        debug_log "No OAuth token available for usage limits" "INFO"
+        echo ""
+        return 1
+    fi
+
+    # Check cache first
+    local cache_key="usage_limits_api"
+    local cached_result
+    cached_result=$(get_cached_value "$cache_key" "$USAGE_LIMITS_CACHE_TTL" 2>/dev/null)
+
+    if [[ -n "$cached_result" ]]; then
+        debug_log "Using cached usage limits" "INFO"
+        echo "$cached_result"
+        return 0
+    fi
+
+    # Fetch from API with HTTP status code capture
+    local response http_code body
+    response=$(curl -s -w "\n%{http_code}" --max-time 5 \
+        -H "Authorization: Bearer $token" \
+        -H "Content-Type: application/json" \
+        -H "anthropic-beta: oauth-2025-04-20" \
+        -H "Accept: application/json" \
+        "https://api.anthropic.com/api/oauth/usage" 2>/dev/null) || {
+        debug_log "OAuth API connection failed (curl error)" "WARN"
+        echo ""
+        return 1
+    }
+
+    # Split response body and HTTP status code
+    http_code=$(echo "$response" | tail -n1)
+    body=$(echo "$response" | sed '$d')
+
+    case "$http_code" in
+        200)
+            if [[ -n "$body" ]] && echo "$body" | jq -e '.five_hour' &>/dev/null; then
+                set_cached_value "$cache_key" "$body" 2>/dev/null
+                debug_log "Fetched fresh usage limits from API (200 OK)" "INFO"
+                echo "$body"
+                return 0
+            else
+                debug_log "OAuth API returned 200 but invalid JSON body" "WARN"
+            fi
+            ;;
+        401)
+            debug_log "OAuth token expired/invalid (401) - re-authenticate Claude Code" "WARN"
+            ;;
+        403)
+            debug_log "OAuth access forbidden (403)" "WARN"
+            ;;
+        429)
+            debug_log "OAuth API rate limited (429) - using cached data if available" "WARN"
+            ;;
+        5[0-9][0-9])
+            debug_log "OAuth API server error ($http_code) - retrying once" "WARN"
+            # Single retry after 2s
+            sleep 2
+            response=$(curl -s -w "\n%{http_code}" --max-time 5 \
+                -H "Authorization: Bearer $token" \
+                -H "Content-Type: application/json" \
+                -H "anthropic-beta: oauth-2025-04-20" \
+                -H "Accept: application/json" \
+                "https://api.anthropic.com/api/oauth/usage" 2>/dev/null) || true
+            http_code=$(echo "$response" | tail -n1)
+            body=$(echo "$response" | sed '$d')
+            if [[ "$http_code" == "200" ]] && echo "$body" | jq -e '.five_hour' &>/dev/null; then
+                set_cached_value "$cache_key" "$body" 2>/dev/null
+                debug_log "OAuth API retry succeeded" "INFO"
+                echo "$body"
+                return 0
+            fi
+            debug_log "OAuth API retry failed ($http_code)" "WARN"
+            ;;
+        "")
+            debug_log "OAuth API timeout or no response" "WARN"
+            ;;
+        *)
+            debug_log "OAuth API unexpected status: $http_code" "WARN"
+            ;;
+    esac
+
+    echo ""
+    return 1
+}
+```
+
+**Step 3: Update `collect_usage_limits_data()` to set status**
+
+At end of `collect_usage_limits_data()`, before `return 0`, add status tracking:
+
+Replace lines 387-392:
+```bash
+        debug_log "usage_limits data: 5h=${COMPONENT_USAGE_FIVE_HOUR}%, 7d=${COMPONENT_USAGE_SEVEN_DAY}%" "INFO"
+    else
+        debug_log "No usage limits data available (no native JSON, no OAuth)" "INFO"
+    fi
+
+    return 0
+```
+With:
+```bash
+        debug_log "usage_limits data: 5h=${COMPONENT_USAGE_FIVE_HOUR}%, 7d=${COMPONENT_USAGE_SEVEN_DAY}%" "INFO"
+        COMPONENT_USAGE_STATUS="ok"
+    else
+        debug_log "No usage limits data available (no native JSON, no OAuth)" "INFO"
+        COMPONENT_USAGE_STATUS="unavailable"
+    fi
+
+    return 0
+```
+
+**Step 4: Run tests**
+
+Run: `bats tests/unit/test_oauth_usage.bats && npm test`
+Expected: All tests PASS
+
+**Step 5: Commit**
+
+```bash
+git add lib/components/usage_limits.sh
+git commit -m "feat: harden OAuth API with HTTP status codes, retry logic, and status tracking"
+```
+
+---
+
+### Task 8: Create version_display Component — Tests
+
+**Files:**
+- Create: `tests/unit/test_version_display.bats`
+
+**Step 1: Write failing tests**
+
+```bash
+#!/usr/bin/env bats
+# ==============================================================================
+# Test: Version Display Component
+# ==============================================================================
+
+load "../setup_suite"
+
+setup() {
+    common_setup
+    STATUSLINE_TESTING="true"
+    export STATUSLINE_TESTING
+    export STATUSLINE_SOURCING=true
+    source "$STATUSLINE_ROOT/lib/core.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/json_fields.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/components.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/components/version_display.sh" 2>/dev/null || true
+}
+
+teardown() {
+    common_teardown
+}
+
+@test "collect_version_display_data extracts version from JSON" {
+    export STATUSLINE_INPUT_JSON='{"version":"2.1.66"}'
+    collect_version_display_data
+    [[ "$COMPONENT_VERSION_DISPLAY_VALUE" == "2.1.66" ]]
+}
+
+@test "collect_version_display_data sets empty when version absent" {
+    export STATUSLINE_INPUT_JSON='{"model":{"display_name":"Opus"}}'
+    collect_version_display_data
+    [[ -z "$COMPONENT_VERSION_DISPLAY_VALUE" ]]
+}
+
+@test "render_version_display shows short format" {
+    COMPONENT_VERSION_DISPLAY_VALUE="2.1.66"
+    CONFIG_VERSION_DISPLAY_FORMAT="short"
+    run render_version_display "false"
+    assert_success
+    assert_output "v2.1.66"
+}
+
+@test "render_version_display shows full format" {
+    COMPONENT_VERSION_DISPLAY_VALUE="2.1.66"
+    CONFIG_VERSION_DISPLAY_FORMAT="full"
+    run render_version_display "false"
+    assert_success
+    assert_output "CC v2.1.66"
+}
+
+@test "render_version_display returns 1 when no version" {
+    COMPONENT_VERSION_DISPLAY_VALUE=""
+    run render_version_display "false"
+    assert_failure
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add tests/unit/test_version_display.bats
+git commit -m "test: add version_display component tests"
+```
+
+---
+
+### Task 9: Create version_display Component — Implementation
+
+**Files:**
+- Create: `lib/components/version_display.sh`
+
+**Step 1: Implement**
+
+```bash
+#!/bin/bash
+
+# ============================================================================
+# Claude Code Statusline - Version Display Component
+# ============================================================================
+#
+# Displays the Claude Code CLI version from native JSON input.
+# Available in Claude Code v2.1.50+
+#
+# Dependencies: json_fields.sh, display.sh
+# ============================================================================
+
+COMPONENT_VERSION_DISPLAY_VALUE=""
+
+collect_version_display_data() {
+    debug_log "Collecting version_display component data" "INFO"
+    COMPONENT_VERSION_DISPLAY_VALUE=""
+
+    if declare -f get_json_field &>/dev/null; then
+        COMPONENT_VERSION_DISPLAY_VALUE=$(get_json_field "version")
+    fi
+
+    debug_log "version_display data: value=$COMPONENT_VERSION_DISPLAY_VALUE" "INFO"
+    return 0
+}
+
+render_version_display() {
+    local theme_enabled="${1:-true}"
+
+    if [[ -z "$COMPONENT_VERSION_DISPLAY_VALUE" ]]; then
+        return 1
+    fi
+
+    local format="${CONFIG_VERSION_DISPLAY_FORMAT:-short}"
+    local color_code=""
+    if [[ "$theme_enabled" == "true" ]] && is_module_loaded "themes"; then
+        color_code="${CONFIG_TEAL:-}"
+    fi
+
+    local output
+    case "$format" in
+        full) output="CC v${COMPONENT_VERSION_DISPLAY_VALUE}" ;;
+        *)    output="v${COMPONENT_VERSION_DISPLAY_VALUE}" ;;
+    esac
+
+    echo "${color_code}${output}${COLOR_RESET}"
+}
+
+get_version_display_config() {
+    local key="${1:-component_name}"
+    local default="${2:-}"
+    case "$key" in
+        "component_name"|"name") echo "version_display" ;;
+        "enabled") echo "${CONFIG_FEATURES_SHOW_VERSION_DISPLAY:-${default:-true}}" ;;
+        "format") echo "${CONFIG_VERSION_DISPLAY_FORMAT:-${default:-short}}" ;;
+        "description") echo "Claude Code CLI version" ;;
+        *) echo "$default" ;;
+    esac
+}
+
+VERSION_DISPLAY_COMPONENT_NAME="version_display"
+VERSION_DISPLAY_COMPONENT_VERSION="2.20.0"
+VERSION_DISPLAY_COMPONENT_DEPENDENCIES=("json_fields")
+
+register_component \
+    "version_display" \
+    "Claude Code CLI version" \
+    "display" \
+    "true"
+
+export -f collect_version_display_data render_version_display get_version_display_config
+debug_log "Version display component loaded" "INFO"
+```
+
+**Step 2: Run tests**
+
+Run: `bats tests/unit/test_version_display.bats`
+Expected: All tests PASS
+
+**Step 3: Commit**
+
+```bash
+git add lib/components/version_display.sh
+git commit -m "feat: add version_display component for Claude Code CLI version"
+```
+
+---
+
+### Task 10: Create vim_mode Component
+
+**Files:**
+- Create: `tests/unit/test_vim_mode.bats`
+- Create: `lib/components/vim_mode.sh`
+
+**Step 1: Write tests**
+
+```bash
+#!/usr/bin/env bats
+load "../setup_suite"
+
+setup() {
+    common_setup
+    export STATUSLINE_TESTING="true"
+    export STATUSLINE_SOURCING=true
+    source "$STATUSLINE_ROOT/lib/core.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/json_fields.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/components.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/components/vim_mode.sh" 2>/dev/null || true
+}
+
+teardown() { common_teardown; }
+
+@test "collect_vim_mode_data extracts NORMAL mode" {
+    export STATUSLINE_INPUT_JSON='{"vim":{"mode":"NORMAL"}}'
+    collect_vim_mode_data
+    [[ "$COMPONENT_VIM_MODE_VALUE" == "NORMAL" ]]
+}
+
+@test "collect_vim_mode_data extracts INSERT mode" {
+    export STATUSLINE_INPUT_JSON='{"vim":{"mode":"INSERT"}}'
+    collect_vim_mode_data
+    [[ "$COMPONENT_VIM_MODE_VALUE" == "INSERT" ]]
+}
+
+@test "collect_vim_mode_data empty when vim not enabled" {
+    export STATUSLINE_INPUT_JSON='{"model":{"display_name":"Opus"}}'
+    collect_vim_mode_data
+    [[ -z "$COMPONENT_VIM_MODE_VALUE" ]]
+}
+
+@test "render_vim_mode shows VIM:NORMAL" {
+    COMPONENT_VIM_MODE_VALUE="NORMAL"
+    run render_vim_mode "false"
+    assert_success
+    assert_output "VIM:NORMAL"
+}
+
+@test "render_vim_mode shows VIM:INSERT" {
+    COMPONENT_VIM_MODE_VALUE="INSERT"
+    run render_vim_mode "false"
+    assert_success
+    assert_output "VIM:INSERT"
+}
+
+@test "render_vim_mode returns 1 when disabled" {
+    COMPONENT_VIM_MODE_VALUE=""
+    run render_vim_mode "false"
+    assert_failure
+}
+```
+
+**Step 2: Implement**
+
+```bash
+#!/bin/bash
+
+# ============================================================================
+# Claude Code Statusline - Vim Mode Component
+# ============================================================================
+#
+# Displays vim mode state (NORMAL/INSERT) when vim mode is enabled.
+# Available in Claude Code v2.1.50+
+#
+# Dependencies: json_fields.sh, display.sh
+# ============================================================================
+
+COMPONENT_VIM_MODE_VALUE=""
+
+collect_vim_mode_data() {
+    debug_log "Collecting vim_mode component data" "INFO"
+    COMPONENT_VIM_MODE_VALUE=""
+
+    if declare -f get_json_field &>/dev/null; then
+        COMPONENT_VIM_MODE_VALUE=$(get_json_field "vim.mode")
+    fi
+
+    debug_log "vim_mode data: value=$COMPONENT_VIM_MODE_VALUE" "INFO"
+    return 0
+}
+
+render_vim_mode() {
+    local theme_enabled="${1:-true}"
+
+    if [[ -z "$COMPONENT_VIM_MODE_VALUE" ]]; then
+        return 1
+    fi
+
+    local color_code=""
+    if [[ "$theme_enabled" == "true" ]] && is_module_loaded "themes"; then
+        case "$COMPONENT_VIM_MODE_VALUE" in
+            NORMAL) color_code="${CONFIG_GREEN:-}" ;;
+            INSERT) color_code="${CONFIG_YELLOW:-}" ;;
+            *) color_code="" ;;
+        esac
+    fi
+
+    echo "${color_code}VIM:${COMPONENT_VIM_MODE_VALUE}${COLOR_RESET}"
+}
+
+get_vim_mode_config() {
+    local key="${1:-component_name}"
+    local default="${2:-}"
+    case "$key" in
+        "component_name"|"name") echo "vim_mode" ;;
+        "enabled") echo "${CONFIG_FEATURES_SHOW_VIM_MODE:-${default:-true}}" ;;
+        "description") echo "Vim mode state (NORMAL/INSERT)" ;;
+        *) echo "$default" ;;
+    esac
+}
+
+VIM_MODE_COMPONENT_NAME="vim_mode"
+VIM_MODE_COMPONENT_VERSION="2.20.0"
+VIM_MODE_COMPONENT_DEPENDENCIES=("json_fields")
+
+register_component "vim_mode" "Vim mode state (NORMAL/INSERT)" "display" "true"
+export -f collect_vim_mode_data render_vim_mode get_vim_mode_config
+debug_log "Vim mode component loaded" "INFO"
+```
+
+**Step 3: Run tests**
+
+Run: `bats tests/unit/test_vim_mode.bats`
+Expected: All tests PASS
+
+**Step 4: Commit**
+
+```bash
+git add tests/unit/test_vim_mode.bats lib/components/vim_mode.sh
+git commit -m "feat: add vim_mode component for vim mode indicator"
+```
+
+---
+
+### Task 11: Create agent_display Component
+
+**Files:**
+- Create: `tests/unit/test_agent_display.bats`
+- Create: `lib/components/agent_display.sh`
+
+**Step 1: Write tests**
+
+```bash
+#!/usr/bin/env bats
+load "../setup_suite"
+
+setup() {
+    common_setup
+    export STATUSLINE_TESTING="true"
+    export STATUSLINE_SOURCING=true
+    source "$STATUSLINE_ROOT/lib/core.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/json_fields.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/components.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/components/agent_display.sh" 2>/dev/null || true
+}
+
+teardown() { common_teardown; }
+
+@test "collect_agent_display_data extracts agent name" {
+    export STATUSLINE_INPUT_JSON='{"agent":{"name":"security-reviewer"}}'
+    collect_agent_display_data
+    [[ "$COMPONENT_AGENT_DISPLAY_NAME" == "security-reviewer" ]]
+}
+
+@test "collect_agent_display_data empty when no agent" {
+    export STATUSLINE_INPUT_JSON='{"model":{"display_name":"Opus"}}'
+    collect_agent_display_data
+    [[ -z "$COMPONENT_AGENT_DISPLAY_NAME" ]]
+}
+
+@test "render_agent_display shows agent name" {
+    COMPONENT_AGENT_DISPLAY_NAME="security-reviewer"
+    run render_agent_display "false"
+    assert_success
+    assert_output "Agent: security-reviewer"
+}
+
+@test "render_agent_display returns 1 when no agent" {
+    COMPONENT_AGENT_DISPLAY_NAME=""
+    run render_agent_display "false"
+    assert_failure
+}
+```
+
+**Step 2: Implement**
+
+```bash
+#!/bin/bash
+
+# ============================================================================
+# Claude Code Statusline - Agent Display Component
+# ============================================================================
+#
+# Displays the agent name when running with --agent flag.
+# Available in Claude Code v2.1.50+
+#
+# Dependencies: json_fields.sh, display.sh
+# ============================================================================
+
+COMPONENT_AGENT_DISPLAY_NAME=""
+
+collect_agent_display_data() {
+    debug_log "Collecting agent_display component data" "INFO"
+    COMPONENT_AGENT_DISPLAY_NAME=""
+
+    if declare -f get_json_field &>/dev/null; then
+        COMPONENT_AGENT_DISPLAY_NAME=$(get_json_field "agent.name")
+    fi
+
+    debug_log "agent_display data: name=$COMPONENT_AGENT_DISPLAY_NAME" "INFO"
+    return 0
+}
+
+render_agent_display() {
+    local theme_enabled="${1:-true}"
+
+    if [[ -z "$COMPONENT_AGENT_DISPLAY_NAME" ]]; then
+        return 1
+    fi
+
+    local color_code=""
+    if [[ "$theme_enabled" == "true" ]] && is_module_loaded "themes"; then
+        color_code="${CONFIG_PURPLE:-\033[95m}"
+    fi
+
+    echo "${color_code}Agent: ${COMPONENT_AGENT_DISPLAY_NAME}${COLOR_RESET}"
+}
+
+get_agent_display_config() {
+    local key="${1:-component_name}"
+    local default="${2:-}"
+    case "$key" in
+        "component_name"|"name") echo "agent_display" ;;
+        "enabled") echo "${CONFIG_FEATURES_SHOW_AGENT_DISPLAY:-${default:-true}}" ;;
+        "description") echo "Agent name when running with --agent" ;;
+        *) echo "$default" ;;
+    esac
+}
+
+AGENT_DISPLAY_COMPONENT_NAME="agent_display"
+AGENT_DISPLAY_COMPONENT_VERSION="2.20.0"
+AGENT_DISPLAY_COMPONENT_DEPENDENCIES=("json_fields")
+
+register_component "agent_display" "Agent name when running with --agent" "display" "true"
+export -f collect_agent_display_data render_agent_display get_agent_display_config
+debug_log "Agent display component loaded" "INFO"
+```
+
+**Step 3: Run tests and commit**
+
+Run: `bats tests/unit/test_agent_display.bats`
+
+```bash
+git add tests/unit/test_agent_display.bats lib/components/agent_display.sh
+git commit -m "feat: add agent_display component for --agent mode indicator"
+```
+
+---
+
+### Task 12: Create context_alert Component
+
+**Files:**
+- Create: `tests/unit/test_context_alert.bats`
+- Create: `lib/components/context_alert.sh`
+
+**Step 1: Write tests**
+
+```bash
+#!/usr/bin/env bats
+load "../setup_suite"
+
+setup() {
+    common_setup
+    export STATUSLINE_TESTING="true"
+    export STATUSLINE_SOURCING=true
+    source "$STATUSLINE_ROOT/lib/core.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/json_fields.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/components.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/components/context_alert.sh" 2>/dev/null || true
+}
+
+teardown() { common_teardown; }
+
+@test "collect_context_alert_data detects exceeded true" {
+    export STATUSLINE_INPUT_JSON='{"exceeds_200k_tokens":true}'
+    collect_context_alert_data
+    [[ "$COMPONENT_CONTEXT_ALERT_EXCEEDED" == "true" ]]
+}
+
+@test "collect_context_alert_data detects exceeded false" {
+    export STATUSLINE_INPUT_JSON='{"exceeds_200k_tokens":false}'
+    collect_context_alert_data
+    [[ "$COMPONENT_CONTEXT_ALERT_EXCEEDED" == "false" ]]
+}
+
+@test "collect_context_alert_data defaults false when missing" {
+    export STATUSLINE_INPUT_JSON='{"model":{"display_name":"Opus"}}'
+    collect_context_alert_data
+    [[ "$COMPONENT_CONTEXT_ALERT_EXCEEDED" == "false" ]]
+}
+
+@test "render_context_alert shows warning when exceeded" {
+    COMPONENT_CONTEXT_ALERT_EXCEEDED="true"
+    run render_context_alert "false"
+    assert_success
+    assert_output --partial ">200K"
+}
+
+@test "render_context_alert returns 1 when not exceeded" {
+    COMPONENT_CONTEXT_ALERT_EXCEEDED="false"
+    run render_context_alert "false"
+    assert_failure
+}
+
+@test "render_context_alert returns 1 when field absent" {
+    COMPONENT_CONTEXT_ALERT_EXCEEDED=""
+    run render_context_alert "false"
+    assert_failure
+}
+```
+
+**Step 2: Implement**
+
+```bash
+#!/bin/bash
+
+# ============================================================================
+# Claude Code Statusline - Context Alert Component
+# ============================================================================
+#
+# Shows a warning when token usage exceeds 200K threshold.
+# Available in Claude Code v2.1.50+
+#
+# Dependencies: json_fields.sh, display.sh
+# ============================================================================
+
+COMPONENT_CONTEXT_ALERT_EXCEEDED=""
+
+collect_context_alert_data() {
+    debug_log "Collecting context_alert component data" "INFO"
+    COMPONENT_CONTEXT_ALERT_EXCEEDED="false"
+
+    if declare -f get_json_field_bool &>/dev/null; then
+        COMPONENT_CONTEXT_ALERT_EXCEEDED=$(get_json_field_bool "exceeds_200k_tokens" "false")
+    fi
+
+    debug_log "context_alert data: exceeded=$COMPONENT_CONTEXT_ALERT_EXCEEDED" "INFO"
+    return 0
+}
+
+render_context_alert() {
+    local theme_enabled="${1:-true}"
+
+    if [[ "$COMPONENT_CONTEXT_ALERT_EXCEEDED" != "true" ]]; then
+        return 1
+    fi
+
+    local color_code="" bold=""
+    if [[ "$theme_enabled" == "true" ]] && is_module_loaded "themes"; then
+        color_code="${CONFIG_RED:-}"
+        bold="${CONFIG_BOLD:-\033[1m}"
+    fi
+
+    local label="${CONFIG_CONTEXT_ALERT_THRESHOLD_LABEL:-">200K"}"
+    echo "${bold}${color_code}${label}${COLOR_RESET}"
+}
+
+get_context_alert_config() {
+    local key="${1:-component_name}"
+    local default="${2:-}"
+    case "$key" in
+        "component_name"|"name") echo "context_alert" ;;
+        "enabled") echo "${CONFIG_FEATURES_SHOW_CONTEXT_ALERT:-${default:-true}}" ;;
+        "description") echo "Warning when tokens exceed 200K threshold" ;;
+        *) echo "$default" ;;
+    esac
+}
+
+CONTEXT_ALERT_COMPONENT_NAME="context_alert"
+CONTEXT_ALERT_COMPONENT_VERSION="2.20.0"
+CONTEXT_ALERT_COMPONENT_DEPENDENCIES=("json_fields")
+
+register_component "context_alert" "Warning when tokens exceed 200K threshold" "display" "true"
+export -f collect_context_alert_data render_context_alert get_context_alert_config
+debug_log "Context alert component loaded" "INFO"
+```
+
+**Step 3: Run tests and commit**
+
+Run: `bats tests/unit/test_context_alert.bats`
+
+```bash
+git add tests/unit/test_context_alert.bats lib/components/context_alert.sh
+git commit -m "feat: add context_alert component for >200K token warning"
+```
+
+---
+
+### Task 13: Create total_tokens Component
+
+**Files:**
+- Create: `tests/unit/test_total_tokens.bats`
+- Create: `lib/components/total_tokens.sh`
+
+**Step 1: Write tests**
+
+```bash
+#!/usr/bin/env bats
+load "../setup_suite"
+
+setup() {
+    common_setup
+    export STATUSLINE_TESTING="true"
+    export STATUSLINE_SOURCING=true
+    source "$STATUSLINE_ROOT/lib/core.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/json_fields.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/components.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/components/total_tokens.sh" 2>/dev/null || true
+}
+
+teardown() { common_teardown; }
+
+@test "collect_total_tokens_data extracts cumulative tokens" {
+    export STATUSLINE_INPUT_JSON='{"context_window":{"total_input_tokens":15234,"total_output_tokens":4521}}'
+    collect_total_tokens_data
+    [[ "$COMPONENT_TOTAL_TOKENS_INPUT" == "15234" ]]
+    [[ "$COMPONENT_TOTAL_TOKENS_OUTPUT" == "4521" ]]
+}
+
+@test "collect_total_tokens_data defaults to 0 when missing" {
+    export STATUSLINE_INPUT_JSON='{"model":{"display_name":"Opus"}}'
+    collect_total_tokens_data
+    [[ "$COMPONENT_TOTAL_TOKENS_INPUT" == "0" ]]
+    [[ "$COMPONENT_TOTAL_TOKENS_OUTPUT" == "0" ]]
+}
+
+@test "render_total_tokens split format" {
+    COMPONENT_TOTAL_TOKENS_INPUT="15234"
+    COMPONENT_TOTAL_TOKENS_OUTPUT="4521"
+    CONFIG_TOTAL_TOKENS_FORMAT="split"
+    run render_total_tokens "false"
+    assert_success
+    assert_output --partial "15.2K in"
+    assert_output --partial "4.5K out"
+}
+
+@test "render_total_tokens compact format" {
+    COMPONENT_TOTAL_TOKENS_INPUT="15234"
+    COMPONENT_TOTAL_TOKENS_OUTPUT="4521"
+    CONFIG_TOTAL_TOKENS_FORMAT="compact"
+    run render_total_tokens "false"
+    assert_success
+    assert_output --partial "19.8K total"
+}
+
+@test "render_total_tokens returns 1 when both zero" {
+    COMPONENT_TOTAL_TOKENS_INPUT="0"
+    COMPONENT_TOTAL_TOKENS_OUTPUT="0"
+    run render_total_tokens "false"
+    assert_failure
+}
+
+@test "render_total_tokens handles millions" {
+    COMPONENT_TOTAL_TOKENS_INPUT="1523400"
+    COMPONENT_TOTAL_TOKENS_OUTPUT="452100"
+    CONFIG_TOTAL_TOKENS_FORMAT="compact"
+    run render_total_tokens "false"
+    assert_success
+    assert_output --partial "M total"
+}
+```
+
+**Step 2: Implement**
+
+```bash
+#!/bin/bash
+
+# ============================================================================
+# Claude Code Statusline - Total Tokens Component
+# ============================================================================
+#
+# Displays cumulative input/output token counts for the session.
+# Available in Claude Code v2.1.50+
+#
+# Dependencies: json_fields.sh, display.sh
+# ============================================================================
+
+COMPONENT_TOTAL_TOKENS_INPUT="0"
+COMPONENT_TOTAL_TOKENS_OUTPUT="0"
+
+# Format token count to human-readable (1.5K, 2.3M)
+_format_tokens_human() {
+    local count="${1:-0}"
+    if [[ "$count" -ge 1000000 ]]; then
+        awk -v c="$count" 'BEGIN { printf "%.1fM", c / 1000000 }' 2>/dev/null
+    elif [[ "$count" -ge 1000 ]]; then
+        awk -v c="$count" 'BEGIN { printf "%.1fK", c / 1000 }' 2>/dev/null
+    else
+        echo "$count"
+    fi
+}
+
+collect_total_tokens_data() {
+    debug_log "Collecting total_tokens component data" "INFO"
+    COMPONENT_TOTAL_TOKENS_INPUT="0"
+    COMPONENT_TOTAL_TOKENS_OUTPUT="0"
+
+    if declare -f get_json_field_num &>/dev/null; then
+        COMPONENT_TOTAL_TOKENS_INPUT=$(get_json_field_num "context_window.total_input_tokens" "0")
+        COMPONENT_TOTAL_TOKENS_OUTPUT=$(get_json_field_num "context_window.total_output_tokens" "0")
+    fi
+
+    debug_log "total_tokens data: in=$COMPONENT_TOTAL_TOKENS_INPUT out=$COMPONENT_TOTAL_TOKENS_OUTPUT" "INFO"
+    return 0
+}
+
+render_total_tokens() {
+    local theme_enabled="${1:-true}"
+
+    local total=$(( COMPONENT_TOTAL_TOKENS_INPUT + COMPONENT_TOTAL_TOKENS_OUTPUT ))
+    if [[ "$total" -eq 0 ]]; then
+        return 1
+    fi
+
+    local format="${CONFIG_TOTAL_TOKENS_FORMAT:-split}"
+    local color_code=""
+    if [[ "$theme_enabled" == "true" ]] && is_module_loaded "themes"; then
+        color_code="${CONFIG_BLUE:-}"
+    fi
+
+    local output
+    case "$format" in
+        compact)
+            local total_fmt
+            total_fmt=$(_format_tokens_human "$total")
+            output="Tokens: ${total_fmt} total"
+            ;;
+        *)
+            local in_fmt out_fmt
+            in_fmt=$(_format_tokens_human "$COMPONENT_TOTAL_TOKENS_INPUT")
+            out_fmt=$(_format_tokens_human "$COMPONENT_TOTAL_TOKENS_OUTPUT")
+            output="Tokens: ${in_fmt} in / ${out_fmt} out"
+            ;;
+    esac
+
+    echo "${color_code}${output}${COLOR_RESET}"
+}
+
+get_total_tokens_config() {
+    local key="${1:-component_name}"
+    local default="${2:-}"
+    case "$key" in
+        "component_name"|"name") echo "total_tokens" ;;
+        "enabled") echo "${CONFIG_FEATURES_SHOW_TOTAL_TOKENS:-${default:-true}}" ;;
+        "format") echo "${CONFIG_TOTAL_TOKENS_FORMAT:-${default:-split}}" ;;
+        "description") echo "Cumulative session token counts" ;;
+        *) echo "$default" ;;
+    esac
+}
+
+TOTAL_TOKENS_COMPONENT_NAME="total_tokens"
+TOTAL_TOKENS_COMPONENT_VERSION="2.20.0"
+TOTAL_TOKENS_COMPONENT_DEPENDENCIES=("json_fields")
+
+register_component "total_tokens" "Cumulative session token counts" "display" "true"
+export -f collect_total_tokens_data render_total_tokens get_total_tokens_config _format_tokens_human
+debug_log "Total tokens component loaded" "INFO"
+```
+
+**Step 3: Run tests and commit**
+
+Run: `bats tests/unit/test_total_tokens.bats`
+
+```bash
+git add tests/unit/test_total_tokens.bats lib/components/total_tokens.sh
+git commit -m "feat: add total_tokens component for cumulative session token display"
+```
+
+---
+
+### Task 14: Update Config.toml
+
+**Files:**
+- Modify: `examples/Config.toml`
+
+**Step 1: Add new component configuration**
+
+Add after the existing `usage_limits` config section:
+
+```toml
+# === v2.20.0 NEW COMPONENTS ===
+# Version Display (Claude Code CLI version from native JSON)
+features.show_version_display = true
+version_display.format = "short"
+
+# Vim Mode (shows VIM:NORMAL or VIM:INSERT when enabled)
+features.show_vim_mode = true
+
+# Agent Display (shows agent name when running with --agent)
+features.show_agent_display = true
+
+# Context Alert (warns when tokens exceed 200K)
+features.show_context_alert = true
+context_alert.show_only_when_exceeded = true
+context_alert.threshold_label = ">200K"
+
+# Total Tokens (cumulative session token counts)
+features.show_total_tokens = true
+total_tokens.format = "split"
+```
+
+**Step 2: Update default display line configurations**
+
+Update the display line component arrays to include new components:
+
+Line 2 — add `version_display` after `model_info`:
+```toml
+display.line2.components = ["model_info", "version_display", "commits", "submodules", "version_info", "time_display"]
+```
+
+Line 4 — add `total_tokens` and `context_alert`:
+```toml
+display.line4.components = ["burn_rate", "cache_efficiency", "block_projection", "total_tokens", "context_alert", "context_window"]
+```
+
+Line 8 — add `vim_mode` and `agent_display`:
+```toml
+display.line8.components = ["mcp_status", "session_mode", "vim_mode", "agent_display"]
+```
+
+**Step 3: Run tests**
+
+Run: `npm test`
+Expected: All tests PASS
+
+**Step 4: Commit**
+
+```bash
+git add examples/Config.toml
+git commit -m "feat: add v2.20.0 component configs and updated default line layouts"
+```
+
+---
+
+### Task 15: Update CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+**Step 1: Update version range**
+
+Change:
+```
+**Current**: v2.19.0 | **Claude Code**: v2.1.6–v2.1.42 ✓
+```
+To:
+```
+**Current**: v2.20.0 | **Claude Code**: v2.1.6–v2.1.66 ✓
+```
+
+**Step 2: Update component count and architecture**
+
+Change `22` atomic components to `27`. Add to the component list:
+
+Under **System** section, change `(2)` to `(4)` and add:
+```
+- **System** (4): mcp_status, time_display, version_display, context_alert
+```
+
+Add new section:
+```
+- **Session** (2): vim_mode, agent_display
+- **Cumulative** (1): total_tokens
+```
+
+**Step 3: Update JSON schema in CLAUDE.md**
+
+Update the JSON input format section to match the official v2.1.66 schema:
+
+```json
+{
+  "cwd": "/current/working/directory",
+  "version": "2.1.66",
+  "workspace": { "current_dir": "/path/to/repo", "project_dir": "/path/to/repo", "added_dirs": [] },
+  "model": { "id": "claude-opus-4-6", "display_name": "Claude Opus 4.5" },
+  "session_id": "uuid-string",
+  "transcript_path": "/path/to/transcript.jsonl",
+  "output_style": { "name": "default" },
+  "context_window": {
+    "total_input_tokens": 15234,
+    "total_output_tokens": 4521,
+    "context_window_size": 200000,
+    "used_percentage": 12,
+    "remaining_percentage": 88,
+    "current_usage": {
+      "input_tokens": 8500,
+      "output_tokens": 1200,
+      "cache_creation_input_tokens": 5000,
+      "cache_read_input_tokens": 2000
+    }
+  },
+  "cost": { "total_cost_usd": 0.45, "total_duration_ms": 60000, "total_api_duration_ms": 30000, "total_lines_added": 120, "total_lines_removed": 30 },
+  "exceeds_200k_tokens": false,
+  "vim": { "mode": "NORMAL" },
+  "agent": { "name": "security-reviewer" },
+  "mcp": { "servers": [] }
+}
+```
+
+Add note:
+```
+**Note**: `five_hour`/`seven_day` usage limit data is NOT available in the statusline JSON. Usage limits are fetched via OAuth API fallback (`https://api.anthropic.com/api/oauth/usage`).
+```
+
+**Step 4: Update Key Functions list**
+
+Add:
+```
+- `get_json_field()` - Safe JSON extraction with path migration
+- `validate_json_schema()` - Startup schema validation and version detection
+```
+
+**Step 5: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: update CLAUDE.md for v2.20.0 with v2.1.66 schema and new components"
+```
+
+---
+
+### Task 16: Run Full Test Suite and Verify
+
+**Files:** None (verification only)
+
+**Step 1: Run all tests**
+
+Run: `npm test`
+Expected: All 838+ tests PASS, plus new tests (~30 new tests across 7 files)
+
+**Step 2: Run lint**
+
+Run: `npm run lint:all`
+Expected: No new lint errors
+
+**Step 3: Run manual integration test with v2.1.66 JSON**
+
+```bash
+echo '{"cwd":"/tmp","version":"2.1.66","workspace":{"current_dir":"'"$(pwd)"'","project_dir":"'"$(pwd)"'"},"model":{"id":"claude-opus-4-6","display_name":"Claude Opus 4.5"},"context_window":{"total_input_tokens":15234,"total_output_tokens":4521,"context_window_size":200000,"used_percentage":12,"remaining_percentage":88,"current_usage":{"input_tokens":8500,"output_tokens":1200,"cache_creation_input_tokens":5000,"cache_read_input_tokens":2000}},"cost":{"total_cost_usd":0.45,"total_duration_ms":60000,"total_api_duration_ms":30000,"total_lines_added":120,"total_lines_removed":30},"exceeds_200k_tokens":false,"vim":{"mode":"NORMAL"},"agent":{"name":"security-reviewer"},"session_id":"test-v2166","mcp":{"servers":[]}}' | /opt/homebrew/bin/bash ~/.claude/statusline/statusline.sh
+```
+
+Expected: All 8 lines render with new components visible:
+- Line 2: model + **v2.1.66** + commits + submodules + version + time
+- Line 4: burn_rate + cache + projection + **Tokens: 15.2K in / 4.5K out** + context
+- Line 8: mcp + session_mode + **VIM:NORMAL** + **Agent: security-reviewer**
+
+**Step 4: Run with legacy JSON (backward compat test)**
+
+```bash
+echo '{"workspace":{"current_dir":"'"$(pwd)"'"},"model":{"display_name":"Claude Opus 4.5"},"context_window":{"used_percentage":12},"cost":{"total_cost_usd":0.45},"current_usage":{"cache_read_input_tokens":5000,"input_tokens":10000},"session_id":"test-legacy","mcp":{"servers":[]}}' | /opt/homebrew/bin/bash ~/.claude/statusline/statusline.sh
+```
+
+Expected: All existing lines render correctly. New components hidden (fields absent). No errors.
+
+**Step 5: Commit final**
+
+If any fixes needed, fix and commit. Then:
+
+```bash
+git log --oneline -15  # Review all commits
+```
+
+---
+
+### Task 17: Update Memory
+
+**Files:**
+- Modify: `~/.claude/projects/-Users-rector-local-dev-claude-code-statusline/memory/MEMORY.md`
+
+**Step 1: Update memory with new patterns**
+
+Add to memory:
+- JSON field access layer (`get_json_field` with path migration)
+- v2.1.66 official schema (no `five_hour`/`seven_day` in statusline JSON)
+- `current_usage` path migration (`context_window.current_usage` canonical, top-level legacy)
+- OAuth API status codes and retry logic
+- New component count: 27
+- Tested version: v2.1.6–v2.1.66
+
+**Step 2: Commit (no git commit needed - memory files are not in repo)**
+
+---
+
+## Execution Summary
+
+| Task | Action | Files | Est. Tests |
+|------|--------|-------|------------|
+| 1 | JSON fields tests | 1 new | 16 tests |
+| 2 | JSON fields impl | 1 new | — |
+| 3 | Integrate into statusline.sh | 1 modify | — |
+| 4 | Migrate native.sh | 1 modify | — |
+| 5 | Migrate recommendations.sh | 1 modify | — |
+| 6 | OAuth tests | 1 new | 6 tests |
+| 7 | OAuth hardening | 1 modify | — |
+| 8 | version_display tests | 1 new | 5 tests |
+| 9 | version_display impl | 1 new | — |
+| 10 | vim_mode test+impl | 2 new | 6 tests |
+| 11 | agent_display test+impl | 2 new | 4 tests |
+| 12 | context_alert test+impl | 2 new | 6 tests |
+| 13 | total_tokens test+impl | 2 new | 6 tests |
+| 14 | Config.toml | 1 modify | — |
+| 15 | CLAUDE.md | 1 modify | — |
+| 16 | Full verification | 0 | Verify all |
+| 17 | Update memory | 1 modify | — |
+
+**Total: 23 files (13 new + 10 modified), ~49 new tests, 17 commits**

--- a/examples/Config.toml
+++ b/examples/Config.toml
@@ -520,7 +520,7 @@ display.line3.components = ["cost_repo", "cost_monthly", "cost_weekly", "cost_da
 display.line3.separator = " │ "
 display.line3.show_when_empty = true
 
-# Line 4: Block Metrics + Code Stats + Context (v2.15.0: restored code_productivity)
+# Line 4: Block Metrics + Token Tracking + Context (v2.20.0: total_tokens + context_alert)
 display.line4.components = ["burn_rate", "cache_efficiency", "block_projection", "total_tokens", "context_alert", "context_window"]
 display.line4.separator = " │ "
 display.line4.show_when_empty = true

--- a/examples/Config.toml
+++ b/examples/Config.toml
@@ -147,6 +147,27 @@ usage_limits.warn_threshold = 50       # Yellow warning above this %
 usage_limits.critical_threshold = 80   # Red critical above this %
 usage_limits.cache_ttl = 300           # API cache TTL in seconds (5 min)
 
+# === v2.20.0 NEW COMPONENTS (Claude Code v2.1.50+) ===
+
+# Version Display (Claude Code CLI version from native JSON)
+features.show_version_display = true
+version_display.format = "short"       # "short" (v2.1.66) or "full" (CC v2.1.66)
+
+# Vim Mode (shows VIM:NORMAL or VIM:INSERT when vim mode enabled)
+features.show_vim_mode = true
+
+# Agent Display (shows agent name when running with --agent flag)
+features.show_agent_display = true
+
+# Context Alert (warns when token usage exceeds 200K threshold)
+features.show_context_alert = true
+context_alert.show_only_when_exceeded = true
+context_alert.threshold_label = ">200K"
+
+# Total Tokens (cumulative session input/output token counts)
+features.show_total_tokens = true
+total_tokens.format = "split"          # "split" (15.2K in / 4.5K out) or "compact" (19.8K total)
+
 # === SESSION INFO CONFIGURATION (Issue #102) ===
 # Display session identification for multi-session awareness.
 # Useful for: resume sessions (claude -r abc12345), debug correlation.
@@ -490,7 +511,7 @@ display.line1.separator = " │ "
 display.line1.show_when_empty = true
 
 # Line 2: Model + Git Metrics & Versions (model first, then commits, submodules hidden when empty, versions, time)
-display.line2.components = ["model_info", "commits", "submodules", "version_info", "time_display"]
+display.line2.components = ["model_info", "version_display", "commits", "submodules", "version_info", "time_display"]
 display.line2.separator = " │ "
 display.line2.show_when_empty = true
 
@@ -500,7 +521,7 @@ display.line3.separator = " │ "
 display.line3.show_when_empty = true
 
 # Line 4: Block Metrics + Code Stats + Context (v2.15.0: restored code_productivity)
-display.line4.components = ["burn_rate", "cache_efficiency", "block_projection", "code_productivity", "context_window"]
+display.line4.components = ["burn_rate", "cache_efficiency", "block_projection", "total_tokens", "context_alert", "context_window"]
 display.line4.separator = " │ "
 display.line4.show_when_empty = true
 
@@ -520,7 +541,7 @@ display.line7.separator = " "
 display.line7.show_when_empty = true
 
 # Line 8: MCP Server Status & Session Mode (output style)
-display.line8.components = ["mcp_status", "session_mode"]
+display.line8.components = ["mcp_status", "session_mode", "vim_mode", "agent_display"]
 display.line8.separator = " │ "
 display.line8.show_when_empty = true
 

--- a/lib/components/agent_display.sh
+++ b/lib/components/agent_display.sh
@@ -10,6 +10,10 @@
 # Dependencies: json_fields.sh, display.sh
 # ============================================================================
 
+# Prevent multiple includes
+[[ "${STATUSLINE_AGENT_DISPLAY_LOADED:-}" == "true" ]] && return 0
+export STATUSLINE_AGENT_DISPLAY_LOADED=true
+
 COMPONENT_AGENT_DISPLAY_NAME=""
 
 collect_agent_display_data() {

--- a/lib/components/agent_display.sh
+++ b/lib/components/agent_display.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# ============================================================================
+# Claude Code Statusline - Agent Display Component
+# ============================================================================
+#
+# Displays the agent name when running with --agent flag.
+# Available in Claude Code v2.1.50+
+#
+# Dependencies: json_fields.sh, display.sh
+# ============================================================================
+
+COMPONENT_AGENT_DISPLAY_NAME=""
+
+collect_agent_display_data() {
+    debug_log "Collecting agent_display component data" "INFO"
+    COMPONENT_AGENT_DISPLAY_NAME=""
+
+    if declare -f get_json_field &>/dev/null; then
+        COMPONENT_AGENT_DISPLAY_NAME=$(get_json_field "agent.name")
+    fi
+
+    debug_log "agent_display data: name=$COMPONENT_AGENT_DISPLAY_NAME" "INFO"
+    return 0
+}
+
+render_agent_display() {
+    local theme_enabled="${1:-true}"
+
+    if [[ -z "$COMPONENT_AGENT_DISPLAY_NAME" ]]; then
+        return 1
+    fi
+
+    local color_code=""
+    if [[ "$theme_enabled" == "true" ]] && is_module_loaded "themes"; then
+        color_code="${CONFIG_PURPLE:-\033[95m}"
+    fi
+
+    echo "${color_code}Agent: ${COMPONENT_AGENT_DISPLAY_NAME}${COLOR_RESET}"
+}
+
+get_agent_display_config() {
+    local key="${1:-component_name}"
+    local default="${2:-}"
+    case "$key" in
+        "component_name"|"name") echo "agent_display" ;;
+        "enabled") echo "${CONFIG_FEATURES_SHOW_AGENT_DISPLAY:-${default:-true}}" ;;
+        "description") echo "Agent name when running with --agent" ;;
+        *) echo "$default" ;;
+    esac
+}
+
+AGENT_DISPLAY_COMPONENT_NAME="agent_display"
+AGENT_DISPLAY_COMPONENT_VERSION="2.20.0"
+AGENT_DISPLAY_COMPONENT_DEPENDENCIES=("json_fields")
+
+register_component "agent_display" "Agent name when running with --agent" "display" "true"
+export -f collect_agent_display_data render_agent_display get_agent_display_config
+debug_log "Agent display component loaded" "INFO"

--- a/lib/components/context_alert.sh
+++ b/lib/components/context_alert.sh
@@ -41,7 +41,7 @@ render_context_alert() {
         bold="${CONFIG_BOLD:-\033[1m}"
     fi
 
-    local label="${CONFIG_CONTEXT_ALERT_THRESHOLD_LABEL:-'>200K'}"
+    local label="${CONFIG_CONTEXT_ALERT_THRESHOLD_LABEL:-\>200K}"
     echo "${bold}${color_code}${label}${COLOR_RESET}"
 }
 

--- a/lib/components/context_alert.sh
+++ b/lib/components/context_alert.sh
@@ -10,6 +10,10 @@
 # Dependencies: json_fields.sh, display.sh
 # ============================================================================
 
+# Prevent multiple includes
+[[ "${STATUSLINE_CONTEXT_ALERT_LOADED:-}" == "true" ]] && return 0
+export STATUSLINE_CONTEXT_ALERT_LOADED=true
+
 COMPONENT_CONTEXT_ALERT_EXCEEDED=""
 
 collect_context_alert_data() {
@@ -37,7 +41,7 @@ render_context_alert() {
         bold="${CONFIG_BOLD:-\033[1m}"
     fi
 
-    local label="${CONFIG_CONTEXT_ALERT_THRESHOLD_LABEL:-">200K"}"
+    local label="${CONFIG_CONTEXT_ALERT_THRESHOLD_LABEL:-'>200K'}"
     echo "${bold}${color_code}${label}${COLOR_RESET}"
 }
 

--- a/lib/components/context_alert.sh
+++ b/lib/components/context_alert.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# ============================================================================
+# Claude Code Statusline - Context Alert Component
+# ============================================================================
+#
+# Shows a warning when token usage exceeds 200K threshold.
+# Available in Claude Code v2.1.50+
+#
+# Dependencies: json_fields.sh, display.sh
+# ============================================================================
+
+COMPONENT_CONTEXT_ALERT_EXCEEDED=""
+
+collect_context_alert_data() {
+    debug_log "Collecting context_alert component data" "INFO"
+    COMPONENT_CONTEXT_ALERT_EXCEEDED="false"
+
+    if declare -f get_json_field_bool &>/dev/null; then
+        COMPONENT_CONTEXT_ALERT_EXCEEDED=$(get_json_field_bool "exceeds_200k_tokens" "false")
+    fi
+
+    debug_log "context_alert data: exceeded=$COMPONENT_CONTEXT_ALERT_EXCEEDED" "INFO"
+    return 0
+}
+
+render_context_alert() {
+    local theme_enabled="${1:-true}"
+
+    if [[ "$COMPONENT_CONTEXT_ALERT_EXCEEDED" != "true" ]]; then
+        return 1
+    fi
+
+    local color_code="" bold=""
+    if [[ "$theme_enabled" == "true" ]] && is_module_loaded "themes"; then
+        color_code="${CONFIG_RED:-}"
+        bold="${CONFIG_BOLD:-\033[1m}"
+    fi
+
+    local label="${CONFIG_CONTEXT_ALERT_THRESHOLD_LABEL:-">200K"}"
+    echo "${bold}${color_code}${label}${COLOR_RESET}"
+}
+
+get_context_alert_config() {
+    local key="${1:-component_name}"
+    local default="${2:-}"
+    case "$key" in
+        "component_name"|"name") echo "context_alert" ;;
+        "enabled") echo "${CONFIG_FEATURES_SHOW_CONTEXT_ALERT:-${default:-true}}" ;;
+        "description") echo "Warning when tokens exceed 200K threshold" ;;
+        *) echo "$default" ;;
+    esac
+}
+
+CONTEXT_ALERT_COMPONENT_NAME="context_alert"
+CONTEXT_ALERT_COMPONENT_VERSION="2.20.0"
+CONTEXT_ALERT_COMPONENT_DEPENDENCIES=("json_fields")
+
+register_component "context_alert" "Warning when tokens exceed 200K threshold" "display" "true"
+export -f collect_context_alert_data render_context_alert get_context_alert_config
+debug_log "Context alert component loaded" "INFO"

--- a/lib/components/total_tokens.sh
+++ b/lib/components/total_tokens.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# ============================================================================
+# Claude Code Statusline - Total Tokens Component
+# ============================================================================
+#
+# Displays cumulative input/output token counts for the session.
+# Available in Claude Code v2.1.50+
+#
+# Dependencies: json_fields.sh, display.sh
+# ============================================================================
+
+COMPONENT_TOTAL_TOKENS_INPUT="0"
+COMPONENT_TOTAL_TOKENS_OUTPUT="0"
+
+# Format token count to human-readable (1.5K, 2.3M)
+_format_tokens_human() {
+    local count="${1:-0}"
+    if [[ "$count" -ge 1000000 ]]; then
+        awk -v c="$count" 'BEGIN { printf "%.1fM", c / 1000000 }' 2>/dev/null
+    elif [[ "$count" -ge 1000 ]]; then
+        awk -v c="$count" 'BEGIN { printf "%.1fK", c / 1000 }' 2>/dev/null
+    else
+        echo "$count"
+    fi
+}
+
+collect_total_tokens_data() {
+    debug_log "Collecting total_tokens component data" "INFO"
+    COMPONENT_TOTAL_TOKENS_INPUT="0"
+    COMPONENT_TOTAL_TOKENS_OUTPUT="0"
+
+    if declare -f get_json_field_num &>/dev/null; then
+        COMPONENT_TOTAL_TOKENS_INPUT=$(get_json_field_num "context_window.total_input_tokens" "0")
+        COMPONENT_TOTAL_TOKENS_OUTPUT=$(get_json_field_num "context_window.total_output_tokens" "0")
+    fi
+
+    debug_log "total_tokens data: in=$COMPONENT_TOTAL_TOKENS_INPUT out=$COMPONENT_TOTAL_TOKENS_OUTPUT" "INFO"
+    return 0
+}
+
+render_total_tokens() {
+    local theme_enabled="${1:-true}"
+
+    local total=$(( COMPONENT_TOTAL_TOKENS_INPUT + COMPONENT_TOTAL_TOKENS_OUTPUT ))
+    if [[ "$total" -eq 0 ]]; then
+        return 1
+    fi
+
+    local format="${CONFIG_TOTAL_TOKENS_FORMAT:-split}"
+    local color_code=""
+    if [[ "$theme_enabled" == "true" ]] && is_module_loaded "themes"; then
+        color_code="${CONFIG_BLUE:-}"
+    fi
+
+    local output
+    case "$format" in
+        compact)
+            local total_fmt
+            total_fmt=$(_format_tokens_human "$total")
+            output="Tokens: ${total_fmt} total"
+            ;;
+        *)
+            local in_fmt out_fmt
+            in_fmt=$(_format_tokens_human "$COMPONENT_TOTAL_TOKENS_INPUT")
+            out_fmt=$(_format_tokens_human "$COMPONENT_TOTAL_TOKENS_OUTPUT")
+            output="Tokens: ${in_fmt} in / ${out_fmt} out"
+            ;;
+    esac
+
+    echo "${color_code}${output}${COLOR_RESET}"
+}
+
+get_total_tokens_config() {
+    local key="${1:-component_name}"
+    local default="${2:-}"
+    case "$key" in
+        "component_name"|"name") echo "total_tokens" ;;
+        "enabled") echo "${CONFIG_FEATURES_SHOW_TOTAL_TOKENS:-${default:-true}}" ;;
+        "format") echo "${CONFIG_TOTAL_TOKENS_FORMAT:-${default:-split}}" ;;
+        "description") echo "Cumulative session token counts" ;;
+        *) echo "$default" ;;
+    esac
+}
+
+TOTAL_TOKENS_COMPONENT_NAME="total_tokens"
+TOTAL_TOKENS_COMPONENT_VERSION="2.20.0"
+TOTAL_TOKENS_COMPONENT_DEPENDENCIES=("json_fields")
+
+register_component "total_tokens" "Cumulative session token counts" "display" "true"
+export -f collect_total_tokens_data render_total_tokens get_total_tokens_config _format_tokens_human
+debug_log "Total tokens component loaded" "INFO"

--- a/lib/components/total_tokens.sh
+++ b/lib/components/total_tokens.sh
@@ -20,6 +20,7 @@ COMPONENT_TOTAL_TOKENS_OUTPUT="0"
 # Format token count to human-readable (1.5K, 2.3M)
 _format_tokens_human() {
     local count="${1:-0}"
+    [[ ! "$count" =~ ^[0-9]+$ ]] && { echo "0"; return; }
     if [[ "$count" -ge 1000000 ]]; then
         awk -v c="$count" 'BEGIN { printf "%.1fM", c / 1000000 }' 2>/dev/null
     elif [[ "$count" -ge 1000 ]]; then
@@ -92,5 +93,5 @@ TOTAL_TOKENS_COMPONENT_VERSION="2.20.0"
 TOTAL_TOKENS_COMPONENT_DEPENDENCIES=("json_fields")
 
 register_component "total_tokens" "Cumulative session token counts" "display" "true"
-export -f collect_total_tokens_data render_total_tokens get_total_tokens_config _format_tokens_human
+export -f collect_total_tokens_data render_total_tokens get_total_tokens_config
 debug_log "Total tokens component loaded" "INFO"

--- a/lib/components/total_tokens.sh
+++ b/lib/components/total_tokens.sh
@@ -10,6 +10,10 @@
 # Dependencies: json_fields.sh, display.sh
 # ============================================================================
 
+# Prevent multiple includes
+[[ "${STATUSLINE_TOTAL_TOKENS_LOADED:-}" == "true" ]] && return 0
+export STATUSLINE_TOTAL_TOKENS_LOADED=true
+
 COMPONENT_TOTAL_TOKENS_INPUT="0"
 COMPONENT_TOTAL_TOKENS_OUTPUT="0"
 

--- a/lib/components/usage_limits.sh
+++ b/lib/components/usage_limits.sh
@@ -20,6 +20,7 @@ COMPONENT_USAGE_FIVE_HOUR=""
 COMPONENT_USAGE_SEVEN_DAY=""
 COMPONENT_USAGE_FIVE_HOUR_RESET=""
 COMPONENT_USAGE_SEVEN_DAY_RESET=""
+COMPONENT_USAGE_STATUS="unknown"
 
 # Cache TTL for usage API (5 minutes - don't spam the API)
 USAGE_LIMITS_CACHE_TTL="${USAGE_LIMITS_CACHE_TTL:-300}"
@@ -312,24 +313,70 @@ fetch_usage_limits() {
         return 0
     fi
 
-    # Fetch from API
-    local response
-    response=$(curl -s --max-time 5 \
+    # Fetch from API with HTTP status code capture
+    local response http_code body
+    response=$(curl -s -w "\n%{http_code}" --max-time 5 \
         -H "Authorization: Bearer $token" \
         -H "Content-Type: application/json" \
         -H "anthropic-beta: oauth-2025-04-20" \
         -H "Accept: application/json" \
-        "https://api.anthropic.com/api/oauth/usage" 2>/dev/null)
+        "https://api.anthropic.com/api/oauth/usage" 2>/dev/null) || {
+        debug_log "OAuth API connection failed (curl error)" "WARN"
+        echo ""
+        return 1
+    }
 
-    if [[ -n "$response" ]] && echo "$response" | jq -e '.five_hour' &>/dev/null; then
-        # Cache the result
-        set_cached_value "$cache_key" "$response" 2>/dev/null
-        debug_log "Fetched fresh usage limits from API" "INFO"
-        echo "$response"
-        return 0
-    fi
+    # Split response body and HTTP status code
+    http_code=$(echo "$response" | tail -n1)
+    body=$(echo "$response" | sed '$d')
 
-    debug_log "Failed to fetch usage limits from API" "WARN"
+    case "$http_code" in
+        200)
+            if [[ -n "$body" ]] && echo "$body" | jq -e '.five_hour' &>/dev/null; then
+                set_cached_value "$cache_key" "$body" 2>/dev/null
+                debug_log "Fetched fresh usage limits from API (200 OK)" "INFO"
+                echo "$body"
+                return 0
+            else
+                debug_log "OAuth API returned 200 but invalid JSON body" "WARN"
+            fi
+            ;;
+        401)
+            debug_log "OAuth token expired/invalid (401) - re-authenticate Claude Code" "WARN"
+            ;;
+        403)
+            debug_log "OAuth access forbidden (403)" "WARN"
+            ;;
+        429)
+            debug_log "OAuth API rate limited (429) - using cached data if available" "WARN"
+            ;;
+        5[0-9][0-9])
+            debug_log "OAuth API server error ($http_code) - retrying once" "WARN"
+            sleep 2
+            response=$(curl -s -w "\n%{http_code}" --max-time 5 \
+                -H "Authorization: Bearer $token" \
+                -H "Content-Type: application/json" \
+                -H "anthropic-beta: oauth-2025-04-20" \
+                -H "Accept: application/json" \
+                "https://api.anthropic.com/api/oauth/usage" 2>/dev/null) || true
+            http_code=$(echo "$response" | tail -n1)
+            body=$(echo "$response" | sed '$d')
+            if [[ "$http_code" == "200" ]] && echo "$body" | jq -e '.five_hour' &>/dev/null; then
+                set_cached_value "$cache_key" "$body" 2>/dev/null
+                debug_log "OAuth API retry succeeded" "INFO"
+                echo "$body"
+                return 0
+            fi
+            debug_log "OAuth API retry failed ($http_code)" "WARN"
+            ;;
+        "")
+            debug_log "OAuth API timeout or no response" "WARN"
+            ;;
+        *)
+            debug_log "OAuth API unexpected status: $http_code" "WARN"
+            ;;
+    esac
+
     echo ""
     return 1
 }
@@ -361,7 +408,7 @@ collect_usage_limits_data() {
 
     # Priority 2: OAuth API fallback (slower, requires token)
     if [[ -z "$usage_data" ]]; then
-        usage_data=$(fetch_usage_limits)
+        usage_data=$(fetch_usage_limits) || true
         if [[ -n "$usage_data" ]]; then
             debug_log "Using OAuth API for usage limits" "INFO"
         fi
@@ -385,8 +432,10 @@ collect_usage_limits_data() {
         fi
 
         debug_log "usage_limits data: 5h=${COMPONENT_USAGE_FIVE_HOUR}%, 7d=${COMPONENT_USAGE_SEVEN_DAY}%" "INFO"
+        COMPONENT_USAGE_STATUS="ok"
     else
         debug_log "No usage limits data available (no native JSON, no OAuth)" "INFO"
+        COMPONENT_USAGE_STATUS="unavailable"
     fi
 
     return 0

--- a/lib/components/usage_limits.sh
+++ b/lib/components/usage_limits.sh
@@ -352,8 +352,8 @@ fetch_usage_limits() {
             ;;
         5[0-9][0-9])
             debug_log "OAuth API server error ($http_code) - retrying once" "WARN"
-            sleep 2
-            response=$(curl -s -w "\n%{http_code}" --max-time 5 \
+            sleep 0.5
+            response=$(curl -s -w "\n%{http_code}" --max-time 2 \
                 -H "Authorization: Bearer $token" \
                 -H "Content-Type: application/json" \
                 -H "anthropic-beta: oauth-2025-04-20" \

--- a/lib/components/version_display.sh
+++ b/lib/components/version_display.sh
@@ -10,6 +10,10 @@
 # Dependencies: json_fields.sh, display.sh
 # ============================================================================
 
+# Prevent multiple includes
+[[ "${STATUSLINE_VERSION_DISPLAY_LOADED:-}" == "true" ]] && return 0
+export STATUSLINE_VERSION_DISPLAY_LOADED=true
+
 COMPONENT_VERSION_DISPLAY_VALUE=""
 
 collect_version_display_data() {

--- a/lib/components/version_display.sh
+++ b/lib/components/version_display.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# ============================================================================
+# Claude Code Statusline - Version Display Component
+# ============================================================================
+#
+# Displays the Claude Code CLI version from native JSON input.
+# Available in Claude Code v2.1.50+
+#
+# Dependencies: json_fields.sh, display.sh
+# ============================================================================
+
+COMPONENT_VERSION_DISPLAY_VALUE=""
+
+collect_version_display_data() {
+    debug_log "Collecting version_display component data" "INFO"
+    COMPONENT_VERSION_DISPLAY_VALUE=""
+
+    if declare -f get_json_field &>/dev/null; then
+        COMPONENT_VERSION_DISPLAY_VALUE=$(get_json_field "version")
+    fi
+
+    debug_log "version_display data: value=$COMPONENT_VERSION_DISPLAY_VALUE" "INFO"
+    return 0
+}
+
+render_version_display() {
+    local theme_enabled="${1:-true}"
+
+    if [[ -z "$COMPONENT_VERSION_DISPLAY_VALUE" ]]; then
+        return 1
+    fi
+
+    local format="${CONFIG_VERSION_DISPLAY_FORMAT:-short}"
+    local color_code=""
+    if [[ "$theme_enabled" == "true" ]] && is_module_loaded "themes"; then
+        color_code="${CONFIG_TEAL:-}"
+    fi
+
+    local output
+    case "$format" in
+        full) output="CC v${COMPONENT_VERSION_DISPLAY_VALUE}" ;;
+        *)    output="v${COMPONENT_VERSION_DISPLAY_VALUE}" ;;
+    esac
+
+    echo "${color_code}${output}${COLOR_RESET}"
+}
+
+get_version_display_config() {
+    local key="${1:-component_name}"
+    local default="${2:-}"
+    case "$key" in
+        "component_name"|"name") echo "version_display" ;;
+        "enabled") echo "${CONFIG_FEATURES_SHOW_VERSION_DISPLAY:-${default:-true}}" ;;
+        "format") echo "${CONFIG_VERSION_DISPLAY_FORMAT:-${default:-short}}" ;;
+        "description") echo "Claude Code CLI version" ;;
+        *) echo "$default" ;;
+    esac
+}
+
+VERSION_DISPLAY_COMPONENT_NAME="version_display"
+VERSION_DISPLAY_COMPONENT_VERSION="2.20.0"
+VERSION_DISPLAY_COMPONENT_DEPENDENCIES=("json_fields")
+
+register_component "version_display" "Claude Code CLI version" "display" "true"
+export -f collect_version_display_data render_version_display get_version_display_config
+debug_log "Version display component loaded" "INFO"

--- a/lib/components/vim_mode.sh
+++ b/lib/components/vim_mode.sh
@@ -10,6 +10,10 @@
 # Dependencies: json_fields.sh, display.sh
 # ============================================================================
 
+# Prevent multiple includes
+[[ "${STATUSLINE_VIM_MODE_LOADED:-}" == "true" ]] && return 0
+export STATUSLINE_VIM_MODE_LOADED=true
+
 COMPONENT_VIM_MODE_VALUE=""
 
 collect_vim_mode_data() {

--- a/lib/components/vim_mode.sh
+++ b/lib/components/vim_mode.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# ============================================================================
+# Claude Code Statusline - Vim Mode Component
+# ============================================================================
+#
+# Displays vim mode state (NORMAL/INSERT) when vim mode is enabled.
+# Available in Claude Code v2.1.50+
+#
+# Dependencies: json_fields.sh, display.sh
+# ============================================================================
+
+COMPONENT_VIM_MODE_VALUE=""
+
+collect_vim_mode_data() {
+    debug_log "Collecting vim_mode component data" "INFO"
+    COMPONENT_VIM_MODE_VALUE=""
+
+    if declare -f get_json_field &>/dev/null; then
+        COMPONENT_VIM_MODE_VALUE=$(get_json_field "vim.mode")
+    fi
+
+    debug_log "vim_mode data: value=$COMPONENT_VIM_MODE_VALUE" "INFO"
+    return 0
+}
+
+render_vim_mode() {
+    local theme_enabled="${1:-true}"
+
+    if [[ -z "$COMPONENT_VIM_MODE_VALUE" ]]; then
+        return 1
+    fi
+
+    local color_code=""
+    if [[ "$theme_enabled" == "true" ]] && is_module_loaded "themes"; then
+        case "$COMPONENT_VIM_MODE_VALUE" in
+            NORMAL) color_code="${CONFIG_GREEN:-}" ;;
+            INSERT) color_code="${CONFIG_YELLOW:-}" ;;
+            *) color_code="" ;;
+        esac
+    fi
+
+    echo "${color_code}VIM:${COMPONENT_VIM_MODE_VALUE}${COLOR_RESET}"
+}
+
+get_vim_mode_config() {
+    local key="${1:-component_name}"
+    local default="${2:-}"
+    case "$key" in
+        "component_name"|"name") echo "vim_mode" ;;
+        "enabled") echo "${CONFIG_FEATURES_SHOW_VIM_MODE:-${default:-true}}" ;;
+        "description") echo "Vim mode state (NORMAL/INSERT)" ;;
+        *) echo "$default" ;;
+    esac
+}
+
+VIM_MODE_COMPONENT_NAME="vim_mode"
+VIM_MODE_COMPONENT_VERSION="2.20.0"
+VIM_MODE_COMPONENT_DEPENDENCIES=("json_fields")
+
+register_component "vim_mode" "Vim mode state (NORMAL/INSERT)" "display" "true"
+export -f collect_vim_mode_data render_vim_mode get_vim_mode_config
+debug_log "Vim mode component loaded" "INFO"

--- a/lib/cost/native.sh
+++ b/lib/cost/native.sh
@@ -96,7 +96,11 @@ get_native_cache_read_tokens() {
     fi
 
     local tokens
-    tokens=$(echo "$STATUSLINE_INPUT_JSON" | jq -r '.current_usage.cache_read_input_tokens // 0' 2>/dev/null)
+    if declare -f get_json_field &>/dev/null; then
+        tokens=$(get_json_field "current_usage.cache_read_input_tokens" "0")
+    else
+        tokens=$(echo "$STATUSLINE_INPUT_JSON" | jq -r '.current_usage.cache_read_input_tokens // 0' 2>/dev/null)
+    fi
     echo "${tokens:-0}"
 }
 
@@ -108,7 +112,11 @@ get_native_cache_creation_tokens() {
     fi
 
     local tokens
-    tokens=$(echo "$STATUSLINE_INPUT_JSON" | jq -r '.current_usage.cache_creation_input_tokens // 0' 2>/dev/null)
+    if declare -f get_json_field &>/dev/null; then
+        tokens=$(get_json_field "current_usage.cache_creation_input_tokens" "0")
+    else
+        tokens=$(echo "$STATUSLINE_INPUT_JSON" | jq -r '.current_usage.cache_creation_input_tokens // 0' 2>/dev/null)
+    fi
     echo "${tokens:-0}"
 }
 

--- a/lib/cost/recommendations.sh
+++ b/lib/cost/recommendations.sh
@@ -360,8 +360,13 @@ generate_recommendations() {
   local cache_hit_rate="0"
   if [[ -n "${STATUSLINE_INPUT_JSON:-}" ]]; then
     local cache_read input_tokens
-    cache_read=$(echo "$STATUSLINE_INPUT_JSON" | jq -r '.current_usage.cache_read_input_tokens // 0' 2>/dev/null) || cache_read=0
-    input_tokens=$(echo "$STATUSLINE_INPUT_JSON" | jq -r '.current_usage.input_tokens // 0' 2>/dev/null) || input_tokens=0
+    if declare -f get_json_field &>/dev/null; then
+      cache_read=$(get_json_field "current_usage.cache_read_input_tokens" "0") || cache_read=0
+      input_tokens=$(get_json_field "current_usage.input_tokens" "0") || input_tokens=0
+    else
+      cache_read=$(echo "$STATUSLINE_INPUT_JSON" | jq -r '.current_usage.cache_read_input_tokens // 0' 2>/dev/null) || cache_read=0
+      input_tokens=$(echo "$STATUSLINE_INPUT_JSON" | jq -r '.current_usage.input_tokens // 0' 2>/dev/null) || input_tokens=0
+    fi
     if [[ "$input_tokens" -gt 0 ]] 2>/dev/null; then
       cache_hit_rate=$(awk -v cr="$cache_read" -v it="$input_tokens" 'BEGIN { printf "%.0f", (cr / it) * 100 }' 2>/dev/null) || cache_hit_rate=0
     fi

--- a/lib/json_fields.sh
+++ b/lib/json_fields.sh
@@ -51,7 +51,7 @@ _JSON_FIELD_MIGRATIONS=(
 # Usage: _dot_to_jq "model.display_name" => ".model.display_name"
 _dot_to_jq() {
   local path="$1"
-  echo ".${path//./.}"
+  echo ".$path"
 }
 
 # Extract a raw value from STATUSLINE_INPUT_JSON using a jq filter
@@ -71,6 +71,39 @@ _jq_extract() {
   fi
 
   echo "$result"
+  return 0
+}
+
+# Resolve a field path through the migration registry
+#
+# If the path matches a migration prefix, outputs two lines:
+#   1. canonical path (new schema, tried first)
+#   2. legacy path (original, tried second)
+# If no migration matches, outputs the original path on one line.
+#
+# Usage: readarray -t paths < <(_resolve_migrated_path "current_usage.input_tokens")
+_resolve_migrated_path() {
+  local field_path="$1"
+
+  local migration
+  for migration in "${_JSON_FIELD_MIGRATIONS[@]}"; do
+    local legacy_prefix="${migration%%|*}"
+    local canonical_prefix="${migration##*|}"
+
+    if [[ "$field_path" == "$legacy_prefix" || "$field_path" == "$legacy_prefix".* ]]; then
+      local suffix="${field_path#"$legacy_prefix"}"
+      local canonical_path="${canonical_prefix}${suffix}"
+
+      debug_log "json_fields: migrating '$field_path' -> trying '$canonical_path' first" "DEBUG"
+
+      echo "$canonical_path"
+      echo "$field_path"
+      return 0
+    fi
+  done
+
+  # No migration match — return original path
+  echo "$field_path"
   return 0
 }
 
@@ -96,45 +129,17 @@ get_json_field() {
     return 0
   fi
 
-  # Check if field_path matches a migration prefix
-  local migration
-  for migration in "${_JSON_FIELD_MIGRATIONS[@]}"; do
-    local legacy_prefix="${migration%%|*}"
-    local canonical_prefix="${migration##*|}"
+  # Resolve through migration registry (may return 1 or 2 paths)
+  local paths
+  readarray -t paths < <(_resolve_migrated_path "$field_path")
 
-    if [[ "$field_path" == "$legacy_prefix" || "$field_path" == "$legacy_prefix".* ]]; then
-      # Build the canonical path by replacing the legacy prefix
-      local suffix="${field_path#"$legacy_prefix"}"
-      local canonical_path="${canonical_prefix}${suffix}"
-
-      debug_log "json_fields: migrating '$field_path' -> trying '$canonical_path' first" "DEBUG"
-
-      # Try canonical path first (new schema)
-      local result
-      if result=$(_jq_extract "$(_dot_to_jq "$canonical_path")"); then
-        echo "$result"
-        return 0
-      fi
-
-      # Fall back to legacy path
-      debug_log "json_fields: canonical path empty, trying legacy '$field_path'" "DEBUG"
-      if result=$(_jq_extract "$(_dot_to_jq "$field_path")"); then
-        echo "$result"
-        return 0
-      fi
-
-      # Neither path had data
-      echo "$default_value"
+  local p result
+  for p in "${paths[@]}"; do
+    if result=$(_jq_extract "$(_dot_to_jq "$p")"); then
+      echo "$result"
       return 0
     fi
   done
-
-  # No migration needed - direct extraction
-  local result
-  if result=$(_jq_extract "$(_dot_to_jq "$field_path")"); then
-    echo "$result"
-    return 0
-  fi
 
   echo "$default_value"
   return 0
@@ -150,13 +155,18 @@ has_json_field() {
 
   [[ -z "$json" ]] && return 1
 
-  local jq_filter
-  jq_filter="$(_dot_to_jq "$field_path")"
+  # Resolve through migration registry
+  local paths
+  readarray -t paths < <(_resolve_migrated_path "$field_path")
 
-  local result
-  result=$(echo "$json" | jq -e "$jq_filter != null and $jq_filter != \"\" " 2>/dev/null) || return 1
+  local p jq_filter result
+  for p in "${paths[@]}"; do
+    jq_filter="$(_dot_to_jq "$p")"
+    result=$(echo "$json" | jq -e "$jq_filter != null and $jq_filter != \"\" " 2>/dev/null) || continue
+    [[ "$result" == "true" ]] && return 0
+  done
 
-  [[ "$result" == "true" ]]
+  return 1
 }
 
 # get_json_field_bool - Extract a boolean field
@@ -173,17 +183,21 @@ get_json_field_bool() {
     return 0
   fi
 
-  local jq_filter
-  jq_filter="$(_dot_to_jq "$field_path")"
+  # Resolve through migration registry
+  local paths
+  readarray -t paths < <(_resolve_migrated_path "$field_path")
 
-  local result
-  result=$(echo "$json" | jq -r "if $jq_filter == true then \"true\" elif $jq_filter == false then \"false\" else empty end" 2>/dev/null) || true
+  local p jq_filter result
+  for p in "${paths[@]}"; do
+    jq_filter="$(_dot_to_jq "$p")"
+    result=$(echo "$json" | jq -r "if $jq_filter == true then \"true\" elif $jq_filter == false then \"false\" else empty end" 2>/dev/null) || true
+    if [[ -n "$result" ]]; then
+      echo "$result"
+      return 0
+    fi
+  done
 
-  if [[ -n "$result" ]]; then
-    echo "$result"
-  else
-    echo "$default_value"
-  fi
+  echo "$default_value"
   return 0
 }
 
@@ -201,17 +215,21 @@ get_json_field_num() {
     return 0
   fi
 
-  local jq_filter
-  jq_filter="$(_dot_to_jq "$field_path")"
+  # Resolve through migration registry
+  local paths
+  readarray -t paths < <(_resolve_migrated_path "$field_path")
 
-  local result
-  result=$(echo "$json" | jq -r "if ($jq_filter | type) == \"number\" then $jq_filter | tostring else empty end" 2>/dev/null) || true
+  local p jq_filter result
+  for p in "${paths[@]}"; do
+    jq_filter="$(_dot_to_jq "$p")"
+    result=$(echo "$json" | jq -r "if ($jq_filter | type) == \"number\" then $jq_filter | tostring else empty end" 2>/dev/null) || true
+    if [[ -n "$result" ]]; then
+      echo "$result"
+      return 0
+    fi
+  done
 
-  if [[ -n "$result" ]]; then
-    echo "$result"
-  else
-    echo "$default_value"
-  fi
+  echo "$default_value"
   return 0
 }
 
@@ -255,7 +273,7 @@ get_detected_cc_version() {
 # EXPORTS
 # ============================================================================
 
-export -f _dot_to_jq _jq_extract
+export -f _dot_to_jq _jq_extract _resolve_migrated_path
 export -f get_json_field has_json_field
 export -f get_json_field_bool get_json_field_num
 export -f validate_json_schema get_detected_cc_version

--- a/lib/json_fields.sh
+++ b/lib/json_fields.sh
@@ -1,0 +1,261 @@
+#!/bin/bash
+
+# ============================================================================
+# Claude Code Statusline - JSON Field Access Abstraction Layer
+# ============================================================================
+#
+# Provides a unified interface for extracting fields from the Claude Code
+# JSON input, with automatic path migration for schema changes across
+# versions (e.g., v2.1.66 moved current_usage under context_window).
+#
+# Path Migration Map:
+#   current_usage.* -> context_window.current_usage.* (v2.1.66+)
+#
+# Dependencies: core.sh (optional - degrades gracefully if unavailable)
+# ============================================================================
+
+# Prevent multiple includes
+[[ "${STATUSLINE_JSON_FIELDS_LOADED:-}" == "true" ]] && return 0
+export STATUSLINE_JSON_FIELDS_LOADED=true
+
+# ============================================================================
+# SAFETY: Ensure debug_log is available (may load before core.sh)
+# ============================================================================
+
+if ! declare -f debug_log &>/dev/null; then
+  debug_log() { :; }
+fi
+
+# ============================================================================
+# INTERNAL: Detected Claude Code version (set by validate_json_schema)
+# ============================================================================
+
+export _STATUSLINE_DETECTED_CC_VERSION="unknown"
+
+# ============================================================================
+# PATH MIGRATION REGISTRY
+# ============================================================================
+# Format: "legacy_prefix|canonical_prefix"
+# When a field_path starts with legacy_prefix, try canonical_prefix first,
+# then fall back to the legacy path.
+
+_JSON_FIELD_MIGRATIONS=(
+  "current_usage|context_window.current_usage"
+)
+
+# ============================================================================
+# CORE FUNCTIONS
+# ============================================================================
+
+# Convert dot-notation path to jq filter
+# Usage: _dot_to_jq "model.display_name" => ".model.display_name"
+_dot_to_jq() {
+  local path="$1"
+  echo ".${path//./.}"
+}
+
+# Extract a raw value from STATUSLINE_INPUT_JSON using a jq filter
+# Returns empty string if extraction fails or value is null
+# Usage: _jq_extract ".model.display_name"
+_jq_extract() {
+  local jq_filter="$1"
+  local json="${STATUSLINE_INPUT_JSON:-}"
+
+  [[ -z "$json" ]] && return 1
+
+  local result
+  result=$(echo "$json" | jq -r "$jq_filter // empty" 2>/dev/null) || return 1
+
+  if [[ -z "$result" || "$result" == "null" ]]; then
+    return 1
+  fi
+
+  echo "$result"
+  return 0
+}
+
+# get_json_field - Extract a field from the Claude Code JSON input
+#
+# Handles path migration transparently: if the requested path matches a
+# known migration prefix, tries the canonical (new) path first, then
+# falls back to the legacy path.
+#
+# Usage: get_json_field "field.path" [default_value]
+# Examples:
+#   get_json_field "model.display_name"              => "Opus"
+#   get_json_field "version" "unknown"                => "2.1.66" or "unknown"
+#   get_json_field "current_usage.input_tokens"       => tries context_window.current_usage.input_tokens first
+get_json_field() {
+  local field_path="$1"
+  local default_value="${2:-}"
+  local json="${STATUSLINE_INPUT_JSON:-}"
+
+  # Fast path: empty JSON -> return default immediately
+  if [[ -z "$json" ]]; then
+    echo "$default_value"
+    return 0
+  fi
+
+  # Check if field_path matches a migration prefix
+  local migration
+  for migration in "${_JSON_FIELD_MIGRATIONS[@]}"; do
+    local legacy_prefix="${migration%%|*}"
+    local canonical_prefix="${migration##*|}"
+
+    if [[ "$field_path" == "$legacy_prefix" || "$field_path" == "$legacy_prefix".* ]]; then
+      # Build the canonical path by replacing the legacy prefix
+      local suffix="${field_path#"$legacy_prefix"}"
+      local canonical_path="${canonical_prefix}${suffix}"
+
+      debug_log "json_fields: migrating '$field_path' -> trying '$canonical_path' first" "DEBUG"
+
+      # Try canonical path first (new schema)
+      local result
+      if result=$(_jq_extract "$(_dot_to_jq "$canonical_path")"); then
+        echo "$result"
+        return 0
+      fi
+
+      # Fall back to legacy path
+      debug_log "json_fields: canonical path empty, trying legacy '$field_path'" "DEBUG"
+      if result=$(_jq_extract "$(_dot_to_jq "$field_path")"); then
+        echo "$result"
+        return 0
+      fi
+
+      # Neither path had data
+      echo "$default_value"
+      return 0
+    fi
+  done
+
+  # No migration needed - direct extraction
+  local result
+  if result=$(_jq_extract "$(_dot_to_jq "$field_path")"); then
+    echo "$result"
+    return 0
+  fi
+
+  echo "$default_value"
+  return 0
+}
+
+# has_json_field - Check if a field exists and is non-null
+#
+# Usage: has_json_field "field.path"
+# Returns: 0 if field exists and is non-null, 1 otherwise
+has_json_field() {
+  local field_path="$1"
+  local json="${STATUSLINE_INPUT_JSON:-}"
+
+  [[ -z "$json" ]] && return 1
+
+  local jq_filter
+  jq_filter="$(_dot_to_jq "$field_path")"
+
+  local result
+  result=$(echo "$json" | jq -e "$jq_filter != null and $jq_filter != \"\" " 2>/dev/null) || return 1
+
+  [[ "$result" == "true" ]]
+}
+
+# get_json_field_bool - Extract a boolean field
+#
+# Usage: get_json_field_bool "field.path" [default]
+# Returns: "true" or "false" (string)
+get_json_field_bool() {
+  local field_path="$1"
+  local default_value="${2:-}"
+  local json="${STATUSLINE_INPUT_JSON:-}"
+
+  if [[ -z "$json" ]]; then
+    echo "$default_value"
+    return 0
+  fi
+
+  local jq_filter
+  jq_filter="$(_dot_to_jq "$field_path")"
+
+  local result
+  result=$(echo "$json" | jq -r "if $jq_filter == true then \"true\" elif $jq_filter == false then \"false\" else empty end" 2>/dev/null) || true
+
+  if [[ -n "$result" ]]; then
+    echo "$result"
+  else
+    echo "$default_value"
+  fi
+  return 0
+}
+
+# get_json_field_num - Extract a numeric field
+#
+# Usage: get_json_field_num "field.path" [default]
+# Returns: numeric value as string, or default
+get_json_field_num() {
+  local field_path="$1"
+  local default_value="${2:-}"
+  local json="${STATUSLINE_INPUT_JSON:-}"
+
+  if [[ -z "$json" ]]; then
+    echo "$default_value"
+    return 0
+  fi
+
+  local jq_filter
+  jq_filter="$(_dot_to_jq "$field_path")"
+
+  local result
+  result=$(echo "$json" | jq -r "if ($jq_filter | type) == \"number\" then $jq_filter | tostring else empty end" 2>/dev/null) || true
+
+  if [[ -n "$result" ]]; then
+    echo "$result"
+  else
+    echo "$default_value"
+  fi
+  return 0
+}
+
+# validate_json_schema - Detect Claude Code version from input JSON
+#
+# Sets _STATUSLINE_DETECTED_CC_VERSION for downstream consumers.
+# Call once after STATUSLINE_INPUT_JSON is populated.
+#
+# Usage: validate_json_schema
+validate_json_schema() {
+  local json="${STATUSLINE_INPUT_JSON:-}"
+
+  if [[ -z "$json" ]]; then
+    export _STATUSLINE_DETECTED_CC_VERSION="unknown"
+    return 0
+  fi
+
+  local version
+  version=$(echo "$json" | jq -r '.version // empty' 2>/dev/null) || true
+
+  if [[ -n "$version" && "$version" != "null" ]]; then
+    export _STATUSLINE_DETECTED_CC_VERSION="$version"
+    debug_log "json_fields: detected Claude Code version: $version" "INFO"
+  else
+    export _STATUSLINE_DETECTED_CC_VERSION="unknown"
+    debug_log "json_fields: no version field in input JSON" "DEBUG"
+  fi
+
+  return 0
+}
+
+# get_detected_cc_version - Return the detected Claude Code version
+#
+# Must call validate_json_schema first.
+# Usage: version=$(get_detected_cc_version)
+get_detected_cc_version() {
+  echo "${_STATUSLINE_DETECTED_CC_VERSION:-unknown}"
+}
+
+# ============================================================================
+# EXPORTS
+# ============================================================================
+
+export -f _dot_to_jq _jq_extract
+export -f get_json_field has_json_field
+export -f get_json_field_bool get_json_field_num
+export -f validate_json_schema get_detected_cc_version

--- a/statusline.sh
+++ b/statusline.sh
@@ -101,6 +101,12 @@ load_module "security" || {
     exit 1
 }
 
+# Load JSON field access abstraction layer (v2.1.66+ path migration)
+# Must load early - provides get_json_field() with current_usage path migration
+load_module "json_fields" || {
+    handle_warning "JSON fields module failed to load - using direct jq extraction" "main"
+}
+
 # Load universal caching module (provides performance optimization for all external commands)
 # Secure file operations via create_secure_cache_file for all cache management
 load_module "cache" || {
@@ -1343,6 +1349,11 @@ input=$(cat)
 # - session_id, transcript_path (session info)
 # See: https://github.com/rz1989s/claude-code-statusline/issues/99
 export STATUSLINE_INPUT_JSON="$input"
+
+# Validate JSON schema and detect Claude Code version (v2.1.66+)
+if declare -f validate_json_schema &>/dev/null; then
+    validate_json_schema
+fi
 
 current_dir=$(echo "$input" | jq -r '.workspace.current_dir')
 # Handle both object format (display_name) and string format for model

--- a/tests/unit/test_agent_display.bats
+++ b/tests/unit/test_agent_display.bats
@@ -1,0 +1,38 @@
+#!/usr/bin/env bats
+load "../setup_suite"
+
+setup() {
+    common_setup
+    export STATUSLINE_TESTING="true"
+    export STATUSLINE_SOURCING=true
+    source "$STATUSLINE_ROOT/lib/core.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/json_fields.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/components.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/components/agent_display.sh" 2>/dev/null || true
+}
+teardown() { common_teardown; }
+
+@test "collect_agent_display_data extracts agent name" {
+    export STATUSLINE_INPUT_JSON='{"agent":{"name":"security-reviewer"}}'
+    collect_agent_display_data
+    [[ "$COMPONENT_AGENT_DISPLAY_NAME" == "security-reviewer" ]]
+}
+
+@test "collect_agent_display_data empty when no agent" {
+    export STATUSLINE_INPUT_JSON='{"model":{"display_name":"Opus"}}'
+    collect_agent_display_data
+    [[ -z "$COMPONENT_AGENT_DISPLAY_NAME" ]]
+}
+
+@test "render_agent_display shows agent name" {
+    COMPONENT_AGENT_DISPLAY_NAME="security-reviewer"
+    run render_agent_display "false"
+    assert_success
+    assert_output "Agent: security-reviewer"
+}
+
+@test "render_agent_display returns 1 when no agent" {
+    COMPONENT_AGENT_DISPLAY_NAME=""
+    run render_agent_display "false"
+    assert_failure
+}

--- a/tests/unit/test_context_alert.bats
+++ b/tests/unit/test_context_alert.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+load "../setup_suite"
+
+setup() {
+    common_setup
+    export STATUSLINE_TESTING="true"
+    export STATUSLINE_SOURCING=true
+    source "$STATUSLINE_ROOT/lib/core.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/json_fields.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/components.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/components/context_alert.sh" 2>/dev/null || true
+}
+teardown() { common_teardown; }
+
+@test "collect_context_alert_data detects exceeded true" {
+    export STATUSLINE_INPUT_JSON='{"exceeds_200k_tokens":true}'
+    collect_context_alert_data
+    [[ "$COMPONENT_CONTEXT_ALERT_EXCEEDED" == "true" ]]
+}
+
+@test "collect_context_alert_data detects exceeded false" {
+    export STATUSLINE_INPUT_JSON='{"exceeds_200k_tokens":false}'
+    collect_context_alert_data
+    [[ "$COMPONENT_CONTEXT_ALERT_EXCEEDED" == "false" ]]
+}
+
+@test "collect_context_alert_data defaults false when missing" {
+    export STATUSLINE_INPUT_JSON='{"model":{"display_name":"Opus"}}'
+    collect_context_alert_data
+    [[ "$COMPONENT_CONTEXT_ALERT_EXCEEDED" == "false" ]]
+}
+
+@test "render_context_alert shows warning when exceeded" {
+    COMPONENT_CONTEXT_ALERT_EXCEEDED="true"
+    run render_context_alert "false"
+    assert_success
+    assert_output --partial ">200K"
+}
+
+@test "render_context_alert returns 1 when not exceeded" {
+    COMPONENT_CONTEXT_ALERT_EXCEEDED="false"
+    run render_context_alert "false"
+    assert_failure
+}
+
+@test "render_context_alert returns 1 when field absent" {
+    COMPONENT_CONTEXT_ALERT_EXCEEDED=""
+    run render_context_alert "false"
+    assert_failure
+}

--- a/tests/unit/test_json_fields.bats
+++ b/tests/unit/test_json_fields.bats
@@ -1,0 +1,198 @@
+#!/usr/bin/env bats
+# ==============================================================================
+# Test: JSON Field Access Abstraction Layer
+# ==============================================================================
+# Tests the JSON field abstraction layer that provides path migration
+# for Claude Code v2.1.66 schema changes (current_usage moved under
+# context_window).
+
+load "../setup_suite"
+
+setup() {
+    common_setup
+    STATUSLINE_TESTING="true"
+    export STATUSLINE_TESTING
+    export STATUSLINE_SOURCING=true
+    source "$STATUSLINE_ROOT/lib/core.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/json_fields.sh" 2>/dev/null || true
+}
+
+teardown() {
+    common_teardown
+}
+
+# ==============================================================================
+# get_json_field: basic extraction
+# ==============================================================================
+
+@test "get_json_field extracts simple top-level field" {
+    export STATUSLINE_INPUT_JSON='{"version":"2.1.66"}'
+    run get_json_field "version"
+    assert_success
+    assert_output "2.1.66"
+}
+
+@test "get_json_field extracts nested field with dot notation" {
+    export STATUSLINE_INPUT_JSON='{"model":{"display_name":"Opus","id":"claude-opus-4-6"}}'
+    run get_json_field "model.display_name"
+    assert_success
+    assert_output "Opus"
+}
+
+@test "get_json_field returns default when field missing" {
+    export STATUSLINE_INPUT_JSON='{"model":{"display_name":"Opus"}}'
+    run get_json_field "version" "unknown"
+    assert_success
+    assert_output "unknown"
+}
+
+@test "get_json_field returns empty string when field missing and no default" {
+    export STATUSLINE_INPUT_JSON='{"model":{"display_name":"Opus"}}'
+    run get_json_field "nonexistent"
+    assert_success
+    assert_output ""
+}
+
+@test "get_json_field handles null JSON values" {
+    export STATUSLINE_INPUT_JSON='{"version":null}'
+    run get_json_field "version" "fallback"
+    assert_success
+    assert_output "fallback"
+}
+
+@test "get_json_field handles empty STATUSLINE_INPUT_JSON" {
+    export STATUSLINE_INPUT_JSON=""
+    run get_json_field "version" "none"
+    assert_success
+    assert_output "none"
+}
+
+# ==============================================================================
+# get_json_field: path migration (current_usage -> context_window.current_usage)
+# ==============================================================================
+
+@test "get_json_field migrates current_usage to context_window.current_usage (new path)" {
+    export STATUSLINE_INPUT_JSON='{"context_window":{"current_usage":{"input_tokens":8500}}}'
+    run get_json_field "current_usage.input_tokens"
+    assert_success
+    assert_output "8500"
+}
+
+@test "get_json_field falls back to legacy current_usage path" {
+    export STATUSLINE_INPUT_JSON='{"current_usage":{"input_tokens":7000}}'
+    run get_json_field "current_usage.input_tokens"
+    assert_success
+    assert_output "7000"
+}
+
+@test "get_json_field prefers new path over legacy" {
+    export STATUSLINE_INPUT_JSON='{"context_window":{"current_usage":{"input_tokens":9000}},"current_usage":{"input_tokens":5000}}'
+    run get_json_field "current_usage.input_tokens"
+    assert_success
+    assert_output "9000"
+}
+
+@test "get_json_field migrates cache_read_input_tokens" {
+    export STATUSLINE_INPUT_JSON='{"context_window":{"current_usage":{"cache_read_input_tokens":3000}}}'
+    run get_json_field "current_usage.cache_read_input_tokens"
+    assert_success
+    assert_output "3000"
+}
+
+@test "get_json_field migrates cache_creation_input_tokens" {
+    export STATUSLINE_INPUT_JSON='{"context_window":{"current_usage":{"cache_creation_input_tokens":2000}}}'
+    run get_json_field "current_usage.cache_creation_input_tokens"
+    assert_success
+    assert_output "2000"
+}
+
+# ==============================================================================
+# has_json_field
+# ==============================================================================
+
+@test "has_json_field returns 0 when field exists" {
+    export STATUSLINE_INPUT_JSON='{"version":"2.1.66"}'
+    run has_json_field "version"
+    assert_success
+}
+
+@test "has_json_field returns 1 when field missing" {
+    export STATUSLINE_INPUT_JSON='{"model":{"display_name":"Opus"}}'
+    run has_json_field "version"
+    assert_failure
+}
+
+@test "has_json_field returns 1 for null field" {
+    export STATUSLINE_INPUT_JSON='{"version":null}'
+    run has_json_field "version"
+    assert_failure
+}
+
+@test "has_json_field detects nested fields" {
+    export STATUSLINE_INPUT_JSON='{"vim":{"mode":"NORMAL"}}'
+    run has_json_field "vim.mode"
+    assert_success
+}
+
+# ==============================================================================
+# validate_json_schema / get_detected_cc_version
+# ==============================================================================
+
+@test "validate_json_schema detects Claude Code version" {
+    export STATUSLINE_INPUT_JSON='{"version":"2.1.66","workspace":{"current_dir":"/tmp"}}'
+    validate_json_schema
+    run get_detected_cc_version
+    assert_success
+    assert_output "2.1.66"
+}
+
+@test "validate_json_schema returns unknown for missing version" {
+    export STATUSLINE_INPUT_JSON='{"workspace":{"current_dir":"/tmp"}}'
+    validate_json_schema
+    run get_detected_cc_version
+    assert_success
+    assert_output "unknown"
+}
+
+# ==============================================================================
+# get_json_field_bool
+# ==============================================================================
+
+@test "get_json_field_bool returns true for true boolean" {
+    export STATUSLINE_INPUT_JSON='{"exceeds_200k_tokens":true}'
+    run get_json_field_bool "exceeds_200k_tokens"
+    assert_success
+    assert_output "true"
+}
+
+@test "get_json_field_bool returns false for false boolean" {
+    export STATUSLINE_INPUT_JSON='{"exceeds_200k_tokens":false}'
+    run get_json_field_bool "exceeds_200k_tokens"
+    assert_success
+    assert_output "false"
+}
+
+@test "get_json_field_bool returns default for missing field" {
+    export STATUSLINE_INPUT_JSON='{"version":"2.1.66"}'
+    run get_json_field_bool "exceeds_200k_tokens" "false"
+    assert_success
+    assert_output "false"
+}
+
+# ==============================================================================
+# get_json_field_num
+# ==============================================================================
+
+@test "get_json_field_num returns numeric value" {
+    export STATUSLINE_INPUT_JSON='{"context_window":{"total_input_tokens":15234}}'
+    run get_json_field_num "context_window.total_input_tokens"
+    assert_success
+    assert_output "15234"
+}
+
+@test "get_json_field_num returns default for missing" {
+    export STATUSLINE_INPUT_JSON='{"model":{"display_name":"Opus"}}'
+    run get_json_field_num "context_window.total_input_tokens" "0"
+    assert_success
+    assert_output "0"
+}

--- a/tests/unit/test_json_fields.bats
+++ b/tests/unit/test_json_fields.bats
@@ -134,6 +134,12 @@ teardown() {
     assert_success
 }
 
+@test "has_json_field returns 1 for empty string field" {
+    export STATUSLINE_INPUT_JSON='{"version":""}'
+    run has_json_field "version"
+    assert_failure
+}
+
 # ==============================================================================
 # validate_json_schema / get_detected_cc_version
 # ==============================================================================
@@ -192,6 +198,13 @@ teardown() {
 
 @test "get_json_field_num returns default for missing" {
     export STATUSLINE_INPUT_JSON='{"model":{"display_name":"Opus"}}'
+    run get_json_field_num "context_window.total_input_tokens" "0"
+    assert_success
+    assert_output "0"
+}
+
+@test "get_json_field_num returns default for non-numeric string" {
+    export STATUSLINE_INPUT_JSON='{"context_window":{"total_input_tokens":"not_a_number"}}'
     run get_json_field_num "context_window.total_input_tokens" "0"
     assert_success
     assert_output "0"

--- a/tests/unit/test_json_fields.bats
+++ b/tests/unit/test_json_fields.bats
@@ -196,3 +196,47 @@ teardown() {
     assert_success
     assert_output "0"
 }
+
+# ==============================================================================
+# Typed extractors: path migration
+# ==============================================================================
+
+@test "has_json_field detects migrated path in new schema" {
+    export STATUSLINE_INPUT_JSON='{"context_window":{"current_usage":{"input_tokens":8500}}}'
+    run has_json_field "current_usage.input_tokens"
+    assert_success
+}
+
+@test "has_json_field detects migrated path in legacy schema" {
+    export STATUSLINE_INPUT_JSON='{"current_usage":{"input_tokens":7000}}'
+    run has_json_field "current_usage.input_tokens"
+    assert_success
+}
+
+@test "get_json_field_num extracts migrated path from new schema" {
+    export STATUSLINE_INPUT_JSON='{"context_window":{"current_usage":{"input_tokens":8500}}}'
+    run get_json_field_num "current_usage.input_tokens" "0"
+    assert_success
+    assert_output "8500"
+}
+
+@test "get_json_field_num falls back to legacy path" {
+    export STATUSLINE_INPUT_JSON='{"current_usage":{"input_tokens":7000}}'
+    run get_json_field_num "current_usage.input_tokens" "0"
+    assert_success
+    assert_output "7000"
+}
+
+@test "get_json_field_bool resolves migrated boolean path" {
+    export STATUSLINE_INPUT_JSON='{"context_window":{"current_usage":{"is_cached":true}}}'
+    run get_json_field_bool "current_usage.is_cached" "false"
+    assert_success
+    assert_output "true"
+}
+
+@test "get_json_field_bool falls back to legacy boolean path" {
+    export STATUSLINE_INPUT_JSON='{"current_usage":{"is_cached":false}}'
+    run get_json_field_bool "current_usage.is_cached" "true"
+    assert_success
+    assert_output "false"
+}

--- a/tests/unit/test_oauth_usage.bats
+++ b/tests/unit/test_oauth_usage.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+# ==============================================================================
+# Test: OAuth Usage Limits API Hardening
+# ==============================================================================
+
+load "../setup_suite"
+
+setup() {
+    common_setup
+    STATUSLINE_TESTING="true"
+    export STATUSLINE_TESTING
+    export STATUSLINE_SOURCING=true
+    source "$STATUSLINE_ROOT/lib/core.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/security.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/cache.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/json_fields.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/components.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/components/usage_limits.sh" 2>/dev/null || true
+}
+
+teardown() {
+    common_teardown
+}
+
+@test "collect_usage_limits_data uses native JSON when five_hour.utilization present" {
+    export STATUSLINE_INPUT_JSON='{"five_hour":{"utilization":22.5,"resets_at":"2026-03-04T19:00:00Z"},"seven_day":{"utilization":54.0,"resets_at":"2026-03-08T08:00:00Z"}}'
+    collect_usage_limits_data
+    [[ "$COMPONENT_USAGE_FIVE_HOUR" == "23" || "$COMPONENT_USAGE_FIVE_HOUR" == "22" ]]
+}
+
+@test "collect_usage_limits_data sets status ok on success" {
+    export STATUSLINE_INPUT_JSON='{"five_hour":{"utilization":22.5,"resets_at":"2026-03-04T19:00:00Z"}}'
+    collect_usage_limits_data
+    [[ "$COMPONENT_USAGE_STATUS" == "ok" ]]
+}
+
+@test "collect_usage_limits_data sets status unavailable on failure" {
+    export STATUSLINE_INPUT_JSON='{"workspace":{"current_dir":"/tmp"}}'
+    # Mock curl and security to fail
+    create_failing_mock_command "curl" "Connection refused"
+    create_failing_mock_command "security" "SecItemNotFound"
+    collect_usage_limits_data
+    [[ "$COMPONENT_USAGE_STATUS" == "unavailable" ]]
+}
+
+@test "collect_usage_limits_data sets empty when no data available" {
+    export STATUSLINE_INPUT_JSON='{"workspace":{"current_dir":"/tmp"}}'
+    create_failing_mock_command "curl" "Connection refused"
+    create_failing_mock_command "security" "SecItemNotFound"
+    collect_usage_limits_data
+    [[ -z "$COMPONENT_USAGE_FIVE_HOUR" ]]
+}
+
+@test "render_usage_reset shows countdown when data available" {
+    export STATUSLINE_INPUT_JSON='{"five_hour":{"utilization":22.5,"resets_at":"2026-03-04T23:00:00Z"},"seven_day":{"utilization":54.0,"resets_at":"2026-03-08T08:00:00Z"}}'
+    collect_usage_limits_data
+    run render_usage_reset "false"
+    assert_success
+    assert_output --partial "5H"
+}
+
+@test "render_usage_reset returns 1 when no data" {
+    COMPONENT_USAGE_FIVE_HOUR=""
+    COMPONENT_USAGE_SEVEN_DAY=""
+    run render_usage_reset "false"
+    assert_failure
+}

--- a/tests/unit/test_total_tokens.bats
+++ b/tests/unit/test_total_tokens.bats
@@ -1,0 +1,62 @@
+#!/usr/bin/env bats
+load "../setup_suite"
+
+setup() {
+    common_setup
+    export STATUSLINE_TESTING="true"
+    export STATUSLINE_SOURCING=true
+    source "$STATUSLINE_ROOT/lib/core.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/json_fields.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/components.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/components/total_tokens.sh" 2>/dev/null || true
+}
+teardown() { common_teardown; }
+
+@test "collect_total_tokens_data extracts cumulative tokens" {
+    export STATUSLINE_INPUT_JSON='{"context_window":{"total_input_tokens":15234,"total_output_tokens":4521}}'
+    collect_total_tokens_data
+    [[ "$COMPONENT_TOTAL_TOKENS_INPUT" == "15234" ]]
+    [[ "$COMPONENT_TOTAL_TOKENS_OUTPUT" == "4521" ]]
+}
+
+@test "collect_total_tokens_data defaults to 0 when missing" {
+    export STATUSLINE_INPUT_JSON='{"model":{"display_name":"Opus"}}'
+    collect_total_tokens_data
+    [[ "$COMPONENT_TOTAL_TOKENS_INPUT" == "0" ]]
+    [[ "$COMPONENT_TOTAL_TOKENS_OUTPUT" == "0" ]]
+}
+
+@test "render_total_tokens split format" {
+    COMPONENT_TOTAL_TOKENS_INPUT="15234"
+    COMPONENT_TOTAL_TOKENS_OUTPUT="4521"
+    CONFIG_TOTAL_TOKENS_FORMAT="split"
+    run render_total_tokens "false"
+    assert_success
+    assert_output --partial "15.2K in"
+    assert_output --partial "4.5K out"
+}
+
+@test "render_total_tokens compact format" {
+    COMPONENT_TOTAL_TOKENS_INPUT="15234"
+    COMPONENT_TOTAL_TOKENS_OUTPUT="4521"
+    CONFIG_TOTAL_TOKENS_FORMAT="compact"
+    run render_total_tokens "false"
+    assert_success
+    assert_output --partial "19.8K total"
+}
+
+@test "render_total_tokens returns 1 when both zero" {
+    COMPONENT_TOTAL_TOKENS_INPUT="0"
+    COMPONENT_TOTAL_TOKENS_OUTPUT="0"
+    run render_total_tokens "false"
+    assert_failure
+}
+
+@test "render_total_tokens handles millions" {
+    COMPONENT_TOTAL_TOKENS_INPUT="1523400"
+    COMPONENT_TOTAL_TOKENS_OUTPUT="452100"
+    CONFIG_TOTAL_TOKENS_FORMAT="compact"
+    run render_total_tokens "false"
+    assert_success
+    assert_output --partial "M total"
+}

--- a/tests/unit/test_version_display.bats
+++ b/tests/unit/test_version_display.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+load "../setup_suite"
+
+setup() {
+    common_setup
+    export STATUSLINE_TESTING="true"
+    export STATUSLINE_SOURCING=true
+    source "$STATUSLINE_ROOT/lib/core.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/json_fields.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/components.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/components/version_display.sh" 2>/dev/null || true
+}
+teardown() { common_teardown; }
+
+@test "collect_version_display_data extracts version from JSON" {
+    export STATUSLINE_INPUT_JSON='{"version":"2.1.66"}'
+    collect_version_display_data
+    [[ "$COMPONENT_VERSION_DISPLAY_VALUE" == "2.1.66" ]]
+}
+
+@test "collect_version_display_data sets empty when version absent" {
+    export STATUSLINE_INPUT_JSON='{"model":{"display_name":"Opus"}}'
+    collect_version_display_data
+    [[ -z "$COMPONENT_VERSION_DISPLAY_VALUE" ]]
+}
+
+@test "render_version_display shows short format" {
+    COMPONENT_VERSION_DISPLAY_VALUE="2.1.66"
+    CONFIG_VERSION_DISPLAY_FORMAT="short"
+    run render_version_display "false"
+    assert_success
+    assert_output "v2.1.66"
+}
+
+@test "render_version_display shows full format" {
+    COMPONENT_VERSION_DISPLAY_VALUE="2.1.66"
+    CONFIG_VERSION_DISPLAY_FORMAT="full"
+    run render_version_display "false"
+    assert_success
+    assert_output "CC v2.1.66"
+}
+
+@test "render_version_display returns 1 when no version" {
+    COMPONENT_VERSION_DISPLAY_VALUE=""
+    run render_version_display "false"
+    assert_failure
+}

--- a/tests/unit/test_vim_mode.bats
+++ b/tests/unit/test_vim_mode.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+load "../setup_suite"
+
+setup() {
+    common_setup
+    export STATUSLINE_TESTING="true"
+    export STATUSLINE_SOURCING=true
+    source "$STATUSLINE_ROOT/lib/core.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/json_fields.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/components.sh" 2>/dev/null || true
+    source "$STATUSLINE_ROOT/lib/components/vim_mode.sh" 2>/dev/null || true
+}
+teardown() { common_teardown; }
+
+@test "collect_vim_mode_data extracts NORMAL mode" {
+    export STATUSLINE_INPUT_JSON='{"vim":{"mode":"NORMAL"}}'
+    collect_vim_mode_data
+    [[ "$COMPONENT_VIM_MODE_VALUE" == "NORMAL" ]]
+}
+
+@test "collect_vim_mode_data extracts INSERT mode" {
+    export STATUSLINE_INPUT_JSON='{"vim":{"mode":"INSERT"}}'
+    collect_vim_mode_data
+    [[ "$COMPONENT_VIM_MODE_VALUE" == "INSERT" ]]
+}
+
+@test "collect_vim_mode_data empty when vim not enabled" {
+    export STATUSLINE_INPUT_JSON='{"model":{"display_name":"Opus"}}'
+    collect_vim_mode_data
+    [[ -z "$COMPONENT_VIM_MODE_VALUE" ]]
+}
+
+@test "render_vim_mode shows VIM:NORMAL" {
+    COMPONENT_VIM_MODE_VALUE="NORMAL"
+    run render_vim_mode "false"
+    assert_success
+    assert_output "VIM:NORMAL"
+}
+
+@test "render_vim_mode shows VIM:INSERT" {
+    COMPONENT_VIM_MODE_VALUE="INSERT"
+    run render_vim_mode "false"
+    assert_success
+    assert_output "VIM:INSERT"
+}
+
+@test "render_vim_mode returns 1 when disabled" {
+    COMPONENT_VIM_MODE_VALUE=""
+    run render_vim_mode "false"
+    assert_failure
+}


### PR DESCRIPTION
## Summary

Full compatibility audit for Claude Code v2.1.66 statusline JSON schema changes, with future-proof architecture and 5 new atomic components.

### Changes

- **JSON Field Abstraction Layer** (`lib/json_fields.sh`): `get_json_field()` with automatic path migration for `current_usage.*` → `context_window.current_usage.*`. Backward compatible with legacy JSON
- **5 New Atomic Components**: `version_display`, `vim_mode`, `agent_display`, `context_alert`, `total_tokens`
- **OAuth API Hardening**: HTTP status code capture, 5xx retry with 2s backoff, explicit `COMPONENT_USAGE_STATUS` tracking
- **Path Migration**: `native.sh` + `recommendations.sh` migrated to `get_json_field()` for dual-path compat
- **Config.toml**: New component feature flags and updated default line layouts
- **CLAUDE.md**: Updated to v2.20.0 with v2.1.66 JSON schema documentation

### Key Finding

`five_hour`/`seven_day` usage limit data was **never in the statusline JSON** — the OAuth API fallback was silently failing due to poor error handling. Now properly hardened.

### New v2.1.66 JSON Fields Supported

`version`, `model.id`, `exceeds_200k_tokens`, `vim.mode`, `agent.name`, `context_window.current_usage.*`, `context_window.total_input_tokens/total_output_tokens`, `workspace.added_dirs`, `cwd`

## Test plan

- [x] 55 new unit tests (json_fields, oauth_usage, version_display, vim_mode, agent_display, context_alert, total_tokens)
- [x] 0 regressions in existing test suite
- [x] Manual integration test with v2.1.66 JSON format
- [x] Manual backward-compat test with legacy JSON format
- [x] All 5 new components render correctly in isolation