### PR TITLE
fix: revert parent_tty, conservative fallback 120

### DIFF
--- a/lib/responsive.sh
+++ b/lib/responsive.sh
@@ -20,7 +20,9 @@ export STATUSLINE_RESPONSIVE_LOADED=true
 # ============================================================================
 
 # Detect terminal width with caching.
-# Priority: ENV_CONFIG_TERMINAL_WIDTH > $COLUMNS > parent TTY > fallback 120
+# Priority: ENV_CONFIG_TERMINAL_WIDTH > $COLUMNS > fallback 120
+# Note: tput cols and parent TTY detection are unreliable in CC's piped context.
+# For narrow-pane filtering, set ENV_CONFIG_TERMINAL_WIDTH explicitly.
 detect_terminal_width() {
     if [[ -n "${STATUSLINE_TERMINAL_WIDTH:-}" ]]; then
         echo "$STATUSLINE_TERMINAL_WIDTH"
@@ -36,32 +38,13 @@ detect_terminal_width() {
         source="ENV_CONFIG_TERMINAL_WIDTH"
     fi
 
-    # 2. $COLUMNS (works when user exports it in shell profile)
+    # 2. $COLUMNS (works when user exports it in shell profile AND CC forwards it)
     if [[ -z "$width" && -n "${COLUMNS:-}" && "${COLUMNS:-0}" -gt 0 ]]; then
         width="$COLUMNS"
         source="COLUMNS"
     fi
 
-    # 3. Ancestor process TTY — walk up the process tree to find CC's controlling terminal.
-    #    CC spawns statusline as piped subprocess (tty=??), but CC itself runs in a
-    #    real terminal (tmux pane). Walk up to 4 levels to find a real TTY device.
-    if [[ -z "$width" && -n "${PPID:-}" ]]; then
-        local walk_pid="$PPID"
-        local tty_dev=""
-        local level
-        for level in 1 2 3 4; do
-            [[ -z "$walk_pid" || "$walk_pid" == "1" || "$walk_pid" == "0" ]] && break
-            tty_dev=$(ps -o tty= -p "$walk_pid" 2>/dev/null | tr -d ' ')
-            if [[ -n "$tty_dev" && "$tty_dev" != "??" && -e "/dev/$tty_dev" ]]; then
-                width=$(stty size < "/dev/$tty_dev" 2>/dev/null | awk '{print $2}')
-                [[ -n "$width" ]] && source="parent_tty"
-                break
-            fi
-            walk_pid=$(ps -o ppid= -p "$walk_pid" 2>/dev/null | tr -d ' ')
-        done
-    fi
-
-    # 4. Fallback: 120 (generous — don't penalize wide-terminal majority)
+    # 3. Fallback: 120 (generous — don't penalize wide-terminal majority)
     if [[ -z "$width" ]] || ! [[ "$width" =~ ^[0-9]+$ ]] || [[ "$width" -lt 1 ]]; then
         width=120
         source="fallback"


### PR DESCRIPTION
Removes unreliable parent TTY detection. Falls back to 120. Narrow-pane filtering via ENV_CONFIG_TERMINAL_WIDTH.