### PR TITLE
chore: remove export COLUMNS and parent_tty — conservative fallback 120

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1158,36 +1158,6 @@ EOF
     return 0
 }
 
-# Function to add 'export COLUMNS' to shell profile for responsive width detection.
-# CC spawns statusline as a piped subprocess where $COLUMNS is unset by default.
-# Exporting it makes the terminal width available to child processes.
-configure_shell_columns() {
-    local shell_profile=""
-
-    # Detect shell profile
-    if [[ -n "${ZSH_VERSION:-}" ]] || [[ "$SHELL" == *"zsh"* ]]; then
-        shell_profile="$HOME/.zshrc"
-    elif [[ -n "${BASH_VERSION:-}" ]] || [[ "$SHELL" == *"bash"* ]]; then
-        shell_profile="$HOME/.bashrc"
-    fi
-
-    if [[ -z "$shell_profile" ]] || [[ ! -f "$shell_profile" ]]; then
-        print_status "Could not detect shell profile — add 'export COLUMNS' manually for responsive width"
-        return 0
-    fi
-
-    # Check if already present
-    if grep -q 'export COLUMNS' "$shell_profile" 2>/dev/null; then
-        print_success "✅ 'export COLUMNS' already in $shell_profile"
-        return 0
-    fi
-
-    # Append to shell profile
-    printf '\n# Claude Code statusline — export terminal width for responsive filtering\nexport COLUMNS\n' >> "$shell_profile"
-    print_success "✅ Added 'export COLUMNS' to $shell_profile (responsive width detection)"
-    return 0
-}
-
 # Function to safely remove directory with robust timeout and fallback protection
 safe_remove_directory() {
     trace_execution "safe_remove_directory $1"
@@ -1698,10 +1668,7 @@ main() {
     print_debug "Step 8: Configuring settings"
     configure_settings
 
-    print_debug "Step 9: Configuring shell profile for responsive width"
-    configure_shell_columns
-
-    print_debug "Step 10: Downloading config template"
+    print_debug "Step 9: Downloading config template"
     download_config_template  # Fail installation if config template download fails
     
     echo

--- a/lib/responsive.sh
+++ b/lib/responsive.sh
@@ -20,7 +20,9 @@ export STATUSLINE_RESPONSIVE_LOADED=true
 # ============================================================================
 
 # Detect terminal width with caching.
-# Priority: ENV_CONFIG_TERMINAL_WIDTH > $COLUMNS > parent TTY > fallback 120
+# Priority: ENV_CONFIG_TERMINAL_WIDTH > $COLUMNS > fallback 120
+# Note: tput cols and parent TTY detection are unreliable in CC's piped context.
+# For narrow-pane filtering, set ENV_CONFIG_TERMINAL_WIDTH explicitly.
 detect_terminal_width() {
     if [[ -n "${STATUSLINE_TERMINAL_WIDTH:-}" ]]; then
         echo "$STATUSLINE_TERMINAL_WIDTH"
@@ -36,32 +38,13 @@ detect_terminal_width() {
         source="ENV_CONFIG_TERMINAL_WIDTH"
     fi
 
-    # 2. $COLUMNS (works when user exports it in shell profile)
+    # 2. $COLUMNS (works if CC forwards it — currently unreliable)
     if [[ -z "$width" && -n "${COLUMNS:-}" && "${COLUMNS:-0}" -gt 0 ]]; then
         width="$COLUMNS"
         source="COLUMNS"
     fi
 
-    # 3. Ancestor process TTY — walk up the process tree to find CC's controlling terminal.
-    #    CC spawns statusline as piped subprocess (tty=??), but CC itself runs in a
-    #    real terminal (tmux pane). Walk up to 4 levels to find a real TTY device.
-    if [[ -z "$width" && -n "${PPID:-}" ]]; then
-        local walk_pid="$PPID"
-        local tty_dev=""
-        local level
-        for level in 1 2 3 4; do
-            [[ -z "$walk_pid" || "$walk_pid" == "1" || "$walk_pid" == "0" ]] && break
-            tty_dev=$(ps -o tty= -p "$walk_pid" 2>/dev/null | tr -d ' ')
-            if [[ -n "$tty_dev" && "$tty_dev" != "??" && -e "/dev/$tty_dev" ]]; then
-                width=$(stty size < "/dev/$tty_dev" 2>/dev/null | awk '{print $2}')
-                [[ -n "$width" ]] && source="parent_tty"
-                break
-            fi
-            walk_pid=$(ps -o ppid= -p "$walk_pid" 2>/dev/null | tr -d ' ')
-        done
-    fi
-
-    # 4. Fallback: 120 (generous — don't penalize wide-terminal majority)
+    # 3. Fallback: 120 (generous — don't penalize wide-terminal majority)
     if [[ -z "$width" ]] || ! [[ "$width" =~ ^[0-9]+$ ]] || [[ "$width" -lt 1 ]]; then
         width=120
         source="fallback"


### PR DESCRIPTION
Removes unreliable width detection (parent_tty, export COLUMNS). Clean fallback to 120. Opt-in for narrow panes via ENV_CONFIG_TERMINAL_WIDTH.