### PR TITLE
chore: promote nightly to main (ssh-agent v0.10.0)

### DIFF
--- a/.github/workflows/mirror-gitlab.yml
+++ b/.github/workflows/mirror-gitlab.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup SSH key
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.GITLAB_SSH_KEY }}
 


### PR DESCRIPTION
## Summary
- ci: bump webfactory/ssh-agent from 0.9.0 to 0.10.0 (node20 → node24)

Routine nightly → main promotion.