### PR TITLE
feat: backfill zero-activity days in --weekly and --monthly reports

### DIFF
--- a/lib/cost/report_calc.sh
+++ b/lib/cost/report_calc.sh
@@ -348,17 +348,56 @@ $awk_pricing
     }
   }")
 
-  # Phase 2: Sort day rows and attach weekday names from shell lookup
+  # Phase 2: Build lookup of aggregated day data
   local model_lines day_lines
   model_lines=$(echo "$raw_data" | grep "^MODEL" || true)
-  day_lines=$(echo "$raw_data" | grep "^_DAY" | sort -t$'\t' -k2 || true)
+  day_lines=$(echo "$raw_data" | grep "^_DAY" || true)
 
-  # Emit DAY lines with weekday names
-  while IFS=$'\t' read -r _ date sessions cost; do
-    [[ -z "$date" ]] && continue
-    local weekday="${weekday_map[$date]:-Unknown}"
-    printf "DAY\t%s\t%s\t%d\t%.2f\n" "$date" "$weekday" "$sessions" "$cost"
-  done <<< "$day_lines"
+  local -A day_data_map
+  if [[ -n "$day_lines" ]]; then
+    while IFS=$'\t' read -r _ d_aggregated d_sess d_cost; do
+      [[ -z "$d_aggregated" ]] && continue
+      day_data_map["$d_aggregated"]="${d_sess}|${d_cost}"
+    done <<< "$day_lines"
+  fi
+
+  # Compute emission range (labeled period — no buffer). Backfills inactive days as $0.
+  # Skip emission entirely when no data exists in the period — preserves "No usage data"
+  # fallback rendering in callers (show_weekly_report / show_monthly_report).
+  if [[ ${#day_data_map[@]} -gt 0 ]]; then
+    local emission_start emission_end
+    if [[ -n "$since_date" ]]; then
+      emission_start="$since_date"
+      emission_end="${until_date:-$(date +%Y-%m-%d)}"
+    else
+      if [[ "$(uname -s)" == "Darwin" ]]; then
+        emission_start=$(date -v-$((days - 1))d +%Y-%m-%d)
+      else
+        emission_start=$(date -d "$((days - 1)) days ago" +%Y-%m-%d)
+      fi
+      emission_end=$(date +%Y-%m-%d)
+    fi
+
+    local cur="$emission_start"
+    local emit_sessions emit_cost emit_weekday entry
+    while [[ "$cur" < "$emission_end" || "$cur" == "$emission_end" ]]; do
+      entry="${day_data_map[$cur]:-}"
+      if [[ -n "$entry" ]]; then
+        emit_sessions="${entry%%|*}"
+        emit_cost="${entry#*|}"
+      else
+        emit_sessions=0
+        emit_cost="0.00"
+      fi
+      emit_weekday="${weekday_map[$cur]:-Unknown}"
+      printf "DAY\t%s\t%s\t%d\t%.2f\n" "$cur" "$emit_weekday" "$emit_sessions" "$emit_cost"
+      if [[ "$(uname -s)" == "Darwin" ]]; then
+        cur=$(date -j -f "%Y-%m-%d" -v+1d "$cur" "+%Y-%m-%d" 2>/dev/null) || break
+      else
+        cur=$(date -d "$cur + 1 day" +%Y-%m-%d 2>/dev/null) || break
+      fi
+    done
+  fi
 
   # Emit MODEL lines
   if [[ -n "$model_lines" ]]; then

--- a/tests/unit/test_zero_day_backfill.bats
+++ b/tests/unit/test_zero_day_backfill.bats
@@ -1,0 +1,248 @@
+#!/usr/bin/env bats
+# ==============================================================================
+# Test: Zero-day backfill in --weekly and --monthly reports
+# ==============================================================================
+# Verifies that inactive days within the report period appear as $0 rows
+# instead of being silently skipped. This makes the daily calendar continuous
+# and prevents readers from mistaking missing dates for a rendering bug.
+
+load "../setup_suite"
+
+setup() {
+    common_setup
+    STATUSLINE_TESTING="true"
+    export STATUSLINE_TESTING
+    export CLAUDE_CONFIG_DIR="$TEST_TMP_DIR/claude_config"
+    mkdir -p "$CLAUDE_CONFIG_DIR/projects/test-project"
+}
+
+teardown() {
+    common_teardown
+}
+
+# Helper: extract JSON object from output
+_extract_json() {
+    local in_json=false
+    local json_lines=""
+    while IFS= read -r line; do
+        if [[ "$line" == "{"* ]]; then
+            in_json=true
+        fi
+        if [[ "$in_json" == "true" ]]; then
+            json_lines+="$line"
+        fi
+        if [[ "$line" == "}" ]]; then
+            break
+        fi
+    done <<< "$1"
+    echo "$json_lines"
+}
+
+# Helper: write a JSONL entry for a given date (YYYY-MM-DD) at noon UTC
+_write_jsonl_entry() {
+    local jsonl_path="$1" date="$2"
+    local model="${3:-claude-sonnet-4-5-20251022}"
+    cat >> "$jsonl_path" <<EOF
+{"type":"assistant","timestamp":"${date}T12:00:00Z","message":{"model":"$model","usage":{"input_tokens":1000,"output_tokens":500,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+EOF
+}
+
+# Helper: get a date N days ago (YYYY-MM-DD) - cross-platform
+_date_n_days_ago() {
+    local n="$1"
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        date -v-${n}d +%Y-%m-%d
+    else
+        date -d "${n} days ago" +%Y-%m-%d
+    fi
+}
+
+# ==============================================================================
+# Weekly report (7 days)
+# ==============================================================================
+
+@test "--weekly --json emits 7 day entries when only 1 day has data" {
+    local jsonl="$CLAUDE_CONFIG_DIR/projects/test-project/session.jsonl"
+    # Only 1 day (3 days ago) has activity
+    _write_jsonl_entry "$jsonl" "$(_date_n_days_ago 3)"
+
+    run "$STATUSLINE_SCRIPT" --weekly --json < /dev/null
+    assert_success
+
+    local json_output days_count
+    json_output=$(_extract_json "$output")
+    days_count=$(echo "$json_output" | jq -r '.days | length')
+    [[ "$days_count" -eq 7 ]] || { echo "Expected 7 days, got $days_count. JSON: $json_output"; return 1; }
+}
+
+@test "--weekly --json zero days have sessions=0 and cost_usd=0" {
+    local jsonl="$CLAUDE_CONFIG_DIR/projects/test-project/session.jsonl"
+    _write_jsonl_entry "$jsonl" "$(_date_n_days_ago 3)"
+
+    run "$STATUSLINE_SCRIPT" --weekly --json < /dev/null
+    assert_success
+
+    local json_output zero_days_count
+    json_output=$(_extract_json "$output")
+    # Count entries where sessions == 0 and cost_usd == 0
+    zero_days_count=$(echo "$json_output" | jq -r '[.days[] | select(.sessions == 0 and .cost_usd == 0)] | length')
+    [[ "$zero_days_count" -eq 6 ]] || { echo "Expected 6 zero days, got $zero_days_count. JSON: $json_output"; return 1; }
+}
+
+@test "--weekly --json days are sorted chronologically" {
+    local jsonl="$CLAUDE_CONFIG_DIR/projects/test-project/session.jsonl"
+    _write_jsonl_entry "$jsonl" "$(_date_n_days_ago 5)"
+    _write_jsonl_entry "$jsonl" "$(_date_n_days_ago 1)"
+
+    run "$STATUSLINE_SCRIPT" --weekly --json < /dev/null
+    assert_success
+
+    local json_output sorted_check
+    json_output=$(_extract_json "$output")
+    # Verify ascending date order
+    sorted_check=$(echo "$json_output" | jq -r '[.days[].date] | . == sort')
+    [[ "$sorted_check" == "true" ]] || { echo "Days not chronologically sorted. JSON: $json_output"; return 1; }
+}
+
+@test "--weekly human-readable shows zero-activity day with \$0.00" {
+    local jsonl="$CLAUDE_CONFIG_DIR/projects/test-project/session.jsonl"
+    local missing_day
+    missing_day="$(_date_n_days_ago 2)"
+    # Activity on other days, but not on `missing_day`
+    _write_jsonl_entry "$jsonl" "$(_date_n_days_ago 5)"
+    _write_jsonl_entry "$jsonl" "$(_date_n_days_ago 1)"
+
+    run "$STATUSLINE_SCRIPT" --weekly < /dev/null
+    assert_success
+    # The missing day's date should appear in the table with $0.00
+    [[ "$output" == *"$missing_day"* ]] || { echo "Expected $missing_day in output. Got: $output"; return 1; }
+}
+
+@test "--weekly with no data at all keeps 'No usage data' message" {
+    # Empty projects dir, no JSONL files
+    run "$STATUSLINE_SCRIPT" --weekly < /dev/null
+    assert_success
+    [[ "$output" == *"No usage data"* ]] || { echo "Expected 'No usage data' for empty input. Got: $output"; return 1; }
+}
+
+@test "--weekly --csv emits 7 rows when only 1 day has data" {
+    local jsonl="$CLAUDE_CONFIG_DIR/projects/test-project/session.jsonl"
+    _write_jsonl_entry "$jsonl" "$(_date_n_days_ago 3)"
+
+    run "$STATUSLINE_SCRIPT" --weekly --csv < /dev/null
+    assert_success
+    # Count rows containing a date (excludes header which has no digits)
+    local data_rows
+    data_rows=$(echo "$output" | grep -cE '[0-9]{4}-[0-9]{2}-[0-9]{2}' || true)
+    [[ "$data_rows" -eq 7 ]] || { echo "Expected 7 CSV data rows, got $data_rows. Output: $output"; return 1; }
+}
+
+# ==============================================================================
+# Monthly report (30 days)
+# ==============================================================================
+
+@test "--monthly --json emits 30 day entries when only 2 days have data" {
+    local jsonl="$CLAUDE_CONFIG_DIR/projects/test-project/session.jsonl"
+    _write_jsonl_entry "$jsonl" "$(_date_n_days_ago 5)"
+    _write_jsonl_entry "$jsonl" "$(_date_n_days_ago 15)"
+
+    run "$STATUSLINE_SCRIPT" --monthly --json < /dev/null
+    assert_success
+
+    local json_output days_count
+    json_output=$(_extract_json "$output")
+    days_count=$(echo "$json_output" | jq -r '.days | length')
+    [[ "$days_count" -eq 30 ]] || { echo "Expected 30 days, got $days_count. JSON: $json_output"; return 1; }
+}
+
+@test "--monthly --json active_days reflects only days with sessions > 0" {
+    local jsonl="$CLAUDE_CONFIG_DIR/projects/test-project/session.jsonl"
+    _write_jsonl_entry "$jsonl" "$(_date_n_days_ago 5)"
+    _write_jsonl_entry "$jsonl" "$(_date_n_days_ago 15)"
+
+    run "$STATUSLINE_SCRIPT" --monthly --json < /dev/null
+    assert_success
+
+    local json_output active_days
+    json_output=$(_extract_json "$output")
+    active_days=$(echo "$json_output" | jq -r '.summary.active_days')
+    [[ "$active_days" -eq 2 ]] || { echo "Expected active_days=2, got $active_days. JSON: $json_output"; return 1; }
+}
+
+@test "--monthly human-readable shows Active Days less than 30 when gaps exist" {
+    local jsonl="$CLAUDE_CONFIG_DIR/projects/test-project/session.jsonl"
+    _write_jsonl_entry "$jsonl" "$(_date_n_days_ago 3)"
+
+    run "$STATUSLINE_SCRIPT" --monthly < /dev/null
+    assert_success
+    # Should display "Active Days: 1 / 30" (only one day has activity)
+    [[ "$output" == *"Active Days:    1 / 30"* ]] || { echo "Expected 'Active Days: 1 / 30'. Got: $output"; return 1; }
+}
+
+@test "--monthly --csv emits 30 rows when only 2 days have data" {
+    local jsonl="$CLAUDE_CONFIG_DIR/projects/test-project/session.jsonl"
+    _write_jsonl_entry "$jsonl" "$(_date_n_days_ago 5)"
+    _write_jsonl_entry "$jsonl" "$(_date_n_days_ago 15)"
+
+    run "$STATUSLINE_SCRIPT" --monthly --csv < /dev/null
+    assert_success
+
+    # Count rows containing a date (excludes header which has no digits)
+    local data_rows
+    data_rows=$(echo "$output" | grep -cE '[0-9]{4}-[0-9]{2}-[0-9]{2}' || true)
+    [[ "$data_rows" -eq 30 ]] || { echo "Expected 30 CSV data rows, got $data_rows. Output: $output"; return 1; }
+}
+
+# ==============================================================================
+# Edge cases: no-gaps, custom ranges, model preservation
+# ==============================================================================
+
+@test "--weekly with data on every day still emits exactly 7 rows" {
+    local jsonl="$CLAUDE_CONFIG_DIR/projects/test-project/session.jsonl"
+    # Activity on all 7 days
+    for n in 0 1 2 3 4 5 6; do
+        _write_jsonl_entry "$jsonl" "$(_date_n_days_ago $n)"
+    done
+
+    run "$STATUSLINE_SCRIPT" --weekly --json < /dev/null
+    assert_success
+
+    local json_output days_count active_days
+    json_output=$(_extract_json "$output")
+    days_count=$(echo "$json_output" | jq -r '.days | length')
+    [[ "$days_count" -eq 7 ]] || { echo "Expected 7 days, got $days_count"; return 1; }
+    # All 7 should be active
+    active_days=$(echo "$json_output" | jq -r '[.days[] | select(.sessions > 0)] | length')
+    [[ "$active_days" -eq 7 ]] || { echo "Expected 7 active days, got $active_days"; return 1; }
+}
+
+@test "--weekly --since custom range backfills inactive days" {
+    local jsonl="$CLAUDE_CONFIG_DIR/projects/test-project/session.jsonl"
+    # Data only on day 3 of a 5-day custom window
+    _write_jsonl_entry "$jsonl" "$(_date_n_days_ago 3)"
+
+    local since until
+    since="$(_date_n_days_ago 5)"
+    until="$(_date_n_days_ago 1)"
+    run "$STATUSLINE_SCRIPT" --weekly --since "$since" --until "$until" --json < /dev/null
+    assert_success
+
+    local json_output days_count
+    json_output=$(_extract_json "$output")
+    days_count=$(echo "$json_output" | jq -r '.days | length')
+    # 5-day inclusive window
+    [[ "$days_count" -eq 5 ]] || { echo "Expected 5 days (since..until inclusive), got $days_count. JSON: $json_output"; return 1; }
+}
+
+@test "--weekly model data still present alongside zero-day rows" {
+    local jsonl="$CLAUDE_CONFIG_DIR/projects/test-project/session.jsonl"
+    _write_jsonl_entry "$jsonl" "$(_date_n_days_ago 2)" "claude-opus-4-7"
+
+    run "$STATUSLINE_SCRIPT" --weekly --json < /dev/null
+    assert_success
+
+    local json_output models_count
+    json_output=$(_extract_json "$output")
+    models_count=$(echo "$json_output" | jq -r '.models | length')
+    [[ "$models_count" -ge 1 ]] || { echo "Expected at least 1 model entry, got $models_count"; return 1; }
+}


### PR DESCRIPTION
## Summary
- `--weekly` and `--monthly` reports now display inactive days as `$0.00` rows instead of silently skipping them, making the day-by-day calendar continuous and preventing rest days from reading as dropped rows.
- Internally consistent: emitted row count now matches the `Period: X to Y` label exactly (7 for weekly, 30 for monthly, `since..until` inclusive for custom ranges).
- `Active Days` stat now reads correctly (e.g., `29 / 30` when one rest day exists in a 30-day window) — existing `$4 > 0` awk filter ignores the new zero rows.

### Before
```
2026-05-15  Friday         6361   $975.03  ████████████████████
2026-05-17  Sunday          544   $124.78  ██
                                          ↑ Saturday silently missing
Active Days: 30 / 30  (misleading)
```

### After
```
2026-05-15  Friday         6361   $975.03  ████████████████████
2026-05-16  Saturday          0     $0.00
2026-05-17  Sunday          544   $124.78  ██
Active Days: 29 / 30  (accurate)
```

## Implementation
- `lib/cost/report_calc.sh`: rewrote Phase 2 of `calculate_daily_breakdown()` to build a date-keyed lookup of aggregated data, then iterate the labeled emission range emitting one row per date — filling missing dates with `sessions=0` and `cost=0.00`.
- Edge case preserved: when no data exists in the period at all, emission is skipped so callers keep the existing `"No usage data for this period."` fallback.

## Scope
- Applies to `--weekly` and `--monthly` (both human-readable, `--json`, and `--csv` formats).
- `--daily` (hourly granularity) is intentionally **not** changed — filling 16+ empty hours of `$0` would add noise without signal, and a fully-inactive day already shows `"No usage data for today."` at the daily level.

## Test plan
- [x] 13 new unit tests in `tests/unit/test_zero_day_backfill.bats` covering single-day data, multi-day data, all-active, custom `--since/--until`, CSV+JSON+human formats, model preservation, no-data fallback, and chronological sort.
- [x] Full local test suite passes (1070 executed / 1072 expected — 2 pre-existing unrelated skips).
- [x] Manual verify on real `~/.claude/projects` data: Saturday 2026-05-16 now renders as `$0.00` row, `Active Days: 29 / 30`.
- [ ] CI green
- [ ] Manual verify after install from nightly