### PR TITLE
fix: de-duplicate transcript cost counting (6–20× overcount) + block-based cache efficiency

### DIFF
--- a/lib/components/cache_efficiency.sh
+++ b/lib/components/cache_efficiency.sh
@@ -26,20 +26,12 @@ collect_cache_efficiency_data() {
     if is_module_loaded "cost"; then
         local got_data=false
 
-        # Try native cache efficiency first (from STATUSLINE_INPUT_JSON)
-        if declare -f get_native_cache_efficiency &>/dev/null; then
-            local native_efficiency
-            native_efficiency=$(get_native_cache_efficiency)
-
-            if [[ -n "$native_efficiency" ]]; then
-                COMPONENT_CACHE_EFFICIENCY_INFO="Cache: ${native_efficiency}% hit"
-                debug_log "Using native cache efficiency: ${native_efficiency}%" "INFO"
-                got_data=true
-            fi
-        fi
-
-        # Fallback: Calculate from JSONL window tokens
-        if [[ "$got_data" == "false" ]] && declare -f get_cached_window_tokens &>/dev/null; then
+        # PRIMARY: block-wide efficiency from the de-duplicated 5-hour window.
+        # This component represents the billing block (like LIVE / burn_rate /
+        # block_projection), so it must aggregate the window — not the current
+        # turn, whose native current_usage can read 0% right after a
+        # cache-creation-heavy turn (e.g. just after /clear or compaction).
+        if declare -f get_cached_window_tokens &>/dev/null; then
             local token_data
             token_data=$(get_cached_window_tokens)
 
@@ -49,7 +41,6 @@ collect_cache_efficiency_data() {
                 cache_read=$(echo "$token_data" | cut -d: -f4)
                 cache_write=$(echo "$token_data" | cut -d: -f5)
 
-                # Calculate cache efficiency percentage
                 if [[ "${cache_read:-0}" -gt 0 || "${cache_write:-0}" -gt 0 ]]; then
                     local total_cache_tokens efficiency
                     total_cache_tokens=$((cache_read + cache_write))
@@ -57,13 +48,23 @@ collect_cache_efficiency_data() {
                     if [[ "$total_cache_tokens" -gt 0 ]]; then
                         efficiency=$(awk -v cr="$cache_read" -v t="$total_cache_tokens" 'BEGIN {printf "%.0f", cr * 100 / t}' 2>/dev/null || echo "0")
                         COMPONENT_CACHE_EFFICIENCY_INFO="Cache: ${efficiency}% hit"
-                        debug_log "Using JSONL cache efficiency: ${efficiency}%" "INFO"
-                    else
-                        COMPONENT_CACHE_EFFICIENCY_INFO="No cache data"
+                        debug_log "Using block cache efficiency: ${efficiency}%" "INFO"
+                        got_data=true
                     fi
-                else
-                    COMPONENT_CACHE_EFFICIENCY_INFO="No cache used"
                 fi
+            fi
+        fi
+
+        # FALLBACK: native current-turn efficiency (from STATUSLINE_INPUT_JSON)
+        # when there is no active 5-hour block (e.g. no rate_limits / OAuth).
+        if [[ "$got_data" == "false" ]] && declare -f get_native_cache_efficiency &>/dev/null; then
+            local native_efficiency
+            native_efficiency=$(get_native_cache_efficiency)
+
+            if [[ -n "$native_efficiency" ]]; then
+                COMPONENT_CACHE_EFFICIENCY_INFO="Cache: ${native_efficiency}% hit"
+                debug_log "Using native cache efficiency (no active block): ${native_efficiency}%" "INFO"
+                got_data=true
             fi
         fi
     fi

--- a/lib/cost/api_live.sh
+++ b/lib/cost/api_live.sh
@@ -219,6 +219,10 @@ calculate_api_synced_live() {
     local awk_pricing
     awk_pricing=$(get_awk_pricing_block)
 
+    # De-duplicate re-logged responses (resume/compaction/sidechain copies)
+    local dedup_block
+    dedup_block=$(get_awk_dedup_block)
+
     # OPTIMIZED: Single jq+awk pipeline
     local total_cost
     total_cost=$(find "$projects_dir" -name "*.jsonl" -type f -mmin -360 2>/dev/null | while read -r jsonl_file; do
@@ -230,7 +234,8 @@ calculate_api_synced_live() {
              (.message.usage.cache_creation.ephemeral_5m_input_tokens // 0),
              (.message.usage.cache_creation.ephemeral_1h_input_tokens // 0),
              (.message.usage.cache_creation_input_tokens // 0),
-             (.message.usage.cache_read_input_tokens // 0)] | @tsv' "$jsonl_file" 2>/dev/null
+             (.message.usage.cache_read_input_tokens // 0),
+             (.message.id // ""), (.requestId // ""), (.uuid // "")] | @tsv' "$jsonl_file" 2>/dev/null
     done | awk -F'\t' -v start="$window_start_iso" "
     BEGIN {
         total = 0
@@ -241,7 +246,7 @@ $awk_pricing
         ts = \$1
         gsub(/\.[0-9]+Z?\$/, \"\", ts)
         if (ts < start) next
-
+$dedup_block
         model = \$2
         input = \$3 + 0
         output = \$4 + 0
@@ -330,7 +335,8 @@ calculate_window_tokens() {
              (.message.usage.input_tokens // 0),
              (.message.usage.output_tokens // 0),
              (.message.usage.cache_read_input_tokens // 0),
-             (.message.usage.cache_creation_input_tokens // 0)] | @tsv' "$jsonl_file" 2>/dev/null
+             (.message.usage.cache_creation_input_tokens // 0),
+             (.message.id // ""), (.requestId // ""), (.uuid // "")] | @tsv' "$jsonl_file" 2>/dev/null
     done | awk -F'\t' -v start="$window_start_iso" '
     BEGIN {
         total_input = 0; total_output = 0; cache_read = 0; cache_write = 0
@@ -339,6 +345,16 @@ calculate_window_tokens() {
         ts = $1
         gsub(/\.[0-9]+Z?$/, "", ts)
         if (ts < start) next
+
+        # De-duplicate re-logged responses by (message.id, requestId), uuid
+        # then NR fallback (awk is single-quoted here; mirrors get_awk_dedup_block)
+        if (NF < 3) next
+        _dk_id = $(NF-2); _dk_req = $(NF-1); _dk_uuid = $NF
+        if (_dk_id != "" && _dk_id != "null") { _dk_key = _dk_id "|" _dk_req }
+        else if (_dk_uuid != "" && _dk_uuid != "null") { _dk_key = "u:" _dk_uuid }
+        else { _dk_key = "n:" NR }
+        if (_dk_key in _dk_seen) next
+        _dk_seen[_dk_key] = 1
 
         total_input += $2 + 0
         total_output += $3 + 0

--- a/lib/cost/commit_attribution.sh
+++ b/lib/cost/commit_attribution.sh
@@ -37,14 +37,23 @@ calculate_commit_costs() {
   local project_jsonl_dir="$projects_dir/$encoded_path"
   [[ -d "$project_jsonl_dir" ]] || return 0
 
-  # Collect all JSONL cost entries with timestamps in one pass
-  local cost_data
+  # Collect all JSONL cost entries with timestamps in one pass.
+  # De-duplicate re-logged responses (resume/compaction/sidechain copies) by
+  # (message.id, requestId) before bucketing, then re-emit [epoch, tokens] so
+  # the downstream sum_cost_in_range stays unchanged.
+  local cost_data dedup_block
+  dedup_block=$(get_awk_dedup_block)
   cost_data=$(find "$project_jsonl_dir" -name "*.jsonl" -type f 2>/dev/null | while read -r f; do
     [[ -f "$f" ]] || continue
     jq -r 'select(.type == "assistant") | select(.message.usage) | select(.timestamp) |
       [(.timestamp | sub("\\.[0-9]+Z?$"; "") | sub("Z$"; "") | . + "Z" | fromdateiso8601 // 0),
-       ((.message.usage.input_tokens // 0) + (.message.usage.output_tokens // 0))] | @tsv' "$f" 2>/dev/null
-  done | sort -t$'\t' -k1 -n)
+       ((.message.usage.input_tokens // 0) + (.message.usage.output_tokens // 0)),
+       (.message.id // ""), (.requestId // ""), (.uuid // "")] | @tsv' "$f" 2>/dev/null
+  done | awk -F'\t' "
+{
+$dedup_block
+  print \$1 \"\t\" \$2
+}" | sort -t$'\t' -k1 -n)
 
   # Build commit windows and attribute costs
   local prev_timestamp=""

--- a/lib/cost/mcp_attribution.sh
+++ b/lib/cost/mcp_attribution.sh
@@ -51,8 +51,9 @@ calculate_mcp_costs() {
   local mcp_data
   mcp_data=$(find "$search_path" -name "*.jsonl" -type f -mtime -30 2>/dev/null | \
     xargs -P4 -L50 jq -r 'select(.type == "assistant") | select(.message.content) |
-      .message.content[] | select(.type == "tool_use") | select(.name | startswith("mcp__")) |
-      .name' 2>/dev/null)
+      (.message.id // .uuid) as $mk |
+      (.message.content | to_entries[] | select(.value.type == "tool_use") | select(.value.name | startswith("mcp__")) |
+       [$mk, .key, .value.name]) | @tsv' 2>/dev/null)
 
   [[ -z "$mcp_data" ]] && return 0
 
@@ -61,10 +62,15 @@ calculate_mcp_costs() {
   local est_tokens_per_call="${CONFIG_MCP_ESTIMATED_TOKENS_PER_CALL:-500}"
 
   # Aggregate by server name
-  echo "$mcp_data" | awk -v est_tokens="$est_tokens_per_call" -v est_cost="$est_cost_per_call" '
+  echo "$mcp_data" | awk -F'\t' -v est_tokens="$est_tokens_per_call" -v est_cost="$est_cost_per_call" '
   {
-    # Extract server name: mcp__SERVER__tool
-    split($0, parts, "__")
+    # De-duplicate re-logged responses: count each (message, tool position) once
+    dk = $1 ":" $2
+    if (dk in seen) next
+    seen[dk] = 1
+
+    # Extract server name from tool name: mcp__SERVER__tool
+    split($3, parts, "__")
     if (length(parts) >= 3) {
       server = parts[2]
       calls[server]++

--- a/lib/cost/native_calc.sh
+++ b/lib/cost/native_calc.sh
@@ -115,6 +115,8 @@ calculate_cost_in_range() {
     # Output format: timestamp|model|input|output|cw_5m|cw_1h|cw_flat|cache_read
     local awk_pricing
     awk_pricing=$(get_awk_pricing_block)
+    local dedup_block
+    dedup_block=$(get_awk_dedup_block)
 
     local total_cost
     total_cost=$(eval "$find_cmd" 2>/dev/null | while read -r jsonl_file; do
@@ -126,7 +128,8 @@ calculate_cost_in_range() {
              (.message.usage.cache_creation.ephemeral_5m_input_tokens // 0),
              (.message.usage.cache_creation.ephemeral_1h_input_tokens // 0),
              (.message.usage.cache_creation_input_tokens // 0),
-             (.message.usage.cache_read_input_tokens // 0)] | @tsv' "$jsonl_file" 2>/dev/null
+             (.message.usage.cache_read_input_tokens // 0),
+             (.message.id // ""), (.requestId // ""), (.uuid // "")] | @tsv' "$jsonl_file" 2>/dev/null
     done | awk -F'\t' -v start="$start_iso" -v end="$end_iso" "
     BEGIN {
         total = 0
@@ -142,7 +145,7 @@ $awk_pricing
         # Check time range
         if (ts < start) next
         if (end != \"\" && ts > end) next
-
+$dedup_block
         model = \$2
         input = \$3 + 0
         output = \$4 + 0
@@ -238,6 +241,8 @@ get_native_usage_info() {
     # Get pricing block from single source of truth
     local awk_pricing
     awk_pricing=$(get_awk_pricing_block)
+    local dedup_block
+    dedup_block=$(get_awk_dedup_block)
 
     # OPTIMIZED: Single jq+awk pass computes ALL periods at once
     local result
@@ -251,7 +256,8 @@ get_native_usage_info() {
              (.message.usage.cache_creation.ephemeral_5m_input_tokens // 0),
              (.message.usage.cache_creation.ephemeral_1h_input_tokens // 0),
              (.message.usage.cache_creation_input_tokens // 0),
-             (.message.usage.cache_read_input_tokens // 0)] | @tsv' "$jsonl_file" 2>/dev/null
+             (.message.usage.cache_read_input_tokens // 0),
+             (.message.id // ""), (.requestId // ""), (.uuid // "")] | @tsv' "$jsonl_file" 2>/dev/null
     done | awk -F'\t' -v today="$today_start" -v week="$week_start" -v month="$month_start" -v project="$sanitized_project" "
     BEGIN {
         daily = 0; weekly = 0; monthly = 0; repo = 0
@@ -259,6 +265,7 @@ get_native_usage_info() {
 $awk_pricing
     }
     {
+$dedup_block
         file = \$1
         ts = \$2
         model = \$3

--- a/lib/cost/pricing.sh
+++ b/lib/cost/pricing.sh
@@ -134,6 +134,38 @@ get_awk_pricing_block() {
 EOF
 }
 
+# Generate awk de-duplication guard for embedding in cost-calculation awk scripts.
+#
+# Claude Code re-logs the SAME assistant API response into transcripts on
+# session resume, compaction, and subagent sidechains — each copy carries the
+# original usage block. Anthropic bills each response (message.id) once, so
+# summing every JSONL occurrence overcounts cost/tokens (observed 6-20x).
+#
+# This block deduplicates by (message.id, requestId), falling back to the
+# per-line uuid when message.id is absent — so distinct calls are never
+# collapsed, only verbatim re-logs of the same response are dropped.
+#
+# REQUIRES: the jq filter must append these as the LAST three @tsv columns:
+#   (.message.id // ""), (.requestId // ""), (.uuid // "")
+# so they resolve to $(NF-2), $(NF-1), $NF regardless of leading column count.
+#
+# PLACEMENT: insert at the top of the awk main block (after any timestamp
+# range filter). All copies of a response share its original timestamp, so
+# placement relative to the range filter does not change results.
+#
+# Usage: dedup_block=$(get_awk_dedup_block)  then embed "$dedup_block" in awk.
+get_awk_dedup_block() {
+    cat <<'EOF'
+        if (NF < 3) next
+        _dk_id = $(NF-2); _dk_req = $(NF-1); _dk_uuid = $NF
+        if (_dk_id != "" && _dk_id != "null") { _dk_key = _dk_id "|" _dk_req }
+        else if (_dk_uuid != "" && _dk_uuid != "null") { _dk_key = "u:" _dk_uuid }
+        else { _dk_key = "n:" NR }
+        if (_dk_key in _dk_seen) next
+        _dk_seen[_dk_key] = 1
+EOF
+}
+
 # Get individual price component
 # Usage: input_price=$(get_model_price "claude-opus-4-6-20250415" "input")
 # Components: input, output, cache_write_5m, cache_write_1h, cache_read
@@ -159,6 +191,6 @@ get_model_price() {
 # EXPORTS
 # ============================================================================
 
-export -f get_model_pricing get_awk_pricing_block get_model_price
+export -f get_model_pricing get_awk_pricing_block get_awk_dedup_block get_model_price
 
 debug_log "Pricing module loaded" "INFO" 2>/dev/null || true

--- a/lib/cost/recommendations.sh
+++ b/lib/cost/recommendations.sh
@@ -56,6 +56,7 @@ CONFIG_RECOMMENDATIONS_IDLE_GAP_MINUTES="${CONFIG_RECOMMENDATIONS_IDLE_GAP_MINUT
 _scan_jsonl_costs() {
   local search_path="$1" find_days="$2" range_start="${3:-}" range_end_iso="${4:-}"
   local awk_end_block="$5" awk_pricing="$6"
+  local dedup_block; dedup_block=$(get_awk_dedup_block)
 
   find "$search_path" -name "*.jsonl" -type f -mtime -$((find_days + 1)) 2>/dev/null | \
     xargs -P4 -L50 jq -r 'select(.type == "assistant") | select(.message.usage) | select(.timestamp) |
@@ -65,7 +66,8 @@ _scan_jsonl_costs() {
        (.message.usage.cache_creation.ephemeral_5m_input_tokens // 0),
        (.message.usage.cache_creation.ephemeral_1h_input_tokens // 0),
        (.message.usage.cache_creation_input_tokens // 0),
-       (.message.usage.cache_read_input_tokens // 0)] | @tsv' 2>/dev/null | awk -F'\t' -v start="$range_start" -v end_ts="$range_end_iso" "
+       (.message.usage.cache_read_input_tokens // 0),
+       (.message.id // ""), (.requestId // ""), (.uuid // "")] | @tsv' 2>/dev/null | awk -F'\t' -v start="$range_start" -v end_ts="$range_end_iso" "
 BEGIN {
 $awk_pricing
   total_cost = 0
@@ -75,7 +77,7 @@ $awk_pricing
   gsub(/\.[0-9]+Z?\$/, \"\", ts)
   if (start != \"\" && ts < start) next
   if (end_ts != \"\" && ts >= end_ts) next
-
+$dedup_block
   model = \$2
   input = \$3 + 0; output = \$4 + 0
   cw_5m = \$5 + 0; cw_1h = \$6 + 0; cw_flat = \$7 + 0; cache_read = \$8 + 0

--- a/lib/cost/report_calc.sh
+++ b/lib/cost/report_calc.sh
@@ -68,6 +68,7 @@ calculate_hourly_breakdown() {
 
   local awk_pricing
   awk_pricing=$(get_awk_pricing_block)
+  local dedup_block; dedup_block=$(get_awk_dedup_block)
 
   # Single find+jq+awk pipeline bucketed by hour
   find "$search_path" -name "*.jsonl" -type f -mtime -1 2>/dev/null | while read -r jsonl_file; do
@@ -79,7 +80,7 @@ calculate_hourly_breakdown() {
        (.message.usage.cache_creation.ephemeral_5m_input_tokens // 0),
        (.message.usage.cache_creation.ephemeral_1h_input_tokens // 0),
        (.message.usage.cache_creation_input_tokens // 0),
-       (.message.usage.cache_read_input_tokens // 0)] | @tsv' "$jsonl_file" 2>/dev/null
+       (.message.usage.cache_read_input_tokens // 0), (.message.id // ""), (.requestId // ""), (.uuid // "")] | @tsv' "$jsonl_file" 2>/dev/null
   done | awk -F'\t' -v start="$today_start" -v end_ts="${range_end_iso:-}" -v tz_offset="$utc_offset_seconds" "
   BEGIN {
     # Pricing
@@ -92,7 +93,7 @@ $awk_pricing
     # Filter to range
     if (ts < start) next
     if (end_ts != \"\" && ts >= end_ts) next
-
+$dedup_block
     model = \$2
     input = \$3 + 0
     output = \$4 + 0
@@ -213,6 +214,7 @@ calculate_daily_breakdown() {
 
   local awk_pricing
   awk_pricing=$(get_awk_pricing_block)
+  local dedup_block; dedup_block=$(get_awk_dedup_block)
 
   # Build weekday lookup for the date range
   # We'll compute weekday names inside awk using a reference point approach
@@ -263,7 +265,7 @@ calculate_daily_breakdown() {
        (.message.usage.cache_creation.ephemeral_5m_input_tokens // 0),
        (.message.usage.cache_creation.ephemeral_1h_input_tokens // 0),
        (.message.usage.cache_creation_input_tokens // 0),
-       (.message.usage.cache_read_input_tokens // 0)] | @tsv' "$jsonl_file" 2>/dev/null
+       (.message.usage.cache_read_input_tokens // 0), (.message.id // ""), (.requestId // ""), (.uuid // "")] | @tsv' "$jsonl_file" 2>/dev/null
   done | awk -F'\t' -v start="$range_start" -v end_ts="${range_end_iso:-}" -v tz_offset="$utc_offset_seconds" "
   BEGIN {
     # Pricing
@@ -276,7 +278,7 @@ $awk_pricing
     # Filter to range
     if (ts < start) next
     if (end_ts != \"\" && ts >= end_ts) next
-
+$dedup_block
     model = \$2
     input = \$3 + 0
     output = \$4 + 0
@@ -451,6 +453,7 @@ calculate_model_breakdown() {
 
   local awk_pricing
   awk_pricing=$(get_awk_pricing_block)
+  local dedup_block; dedup_block=$(get_awk_dedup_block)
 
   find "$search_path" -name "*.jsonl" -type f -mtime -$((find_days + 1)) 2>/dev/null | while read -r jsonl_file; do
     [[ -z "$jsonl_file" ]] && continue
@@ -461,7 +464,7 @@ calculate_model_breakdown() {
        (.message.usage.cache_creation.ephemeral_5m_input_tokens // 0),
        (.message.usage.cache_creation.ephemeral_1h_input_tokens // 0),
        (.message.usage.cache_creation_input_tokens // 0),
-       (.message.usage.cache_read_input_tokens // 0)] | @tsv' "$jsonl_file" 2>/dev/null
+       (.message.usage.cache_read_input_tokens // 0), (.message.id // ""), (.requestId // ""), (.uuid // "")] | @tsv' "$jsonl_file" 2>/dev/null
   done | awk -F'\t' -v start="$range_start" -v end_ts="${range_end_iso:-}" "
   BEGIN {
 $awk_pricing
@@ -472,7 +475,7 @@ $awk_pricing
 
     if (ts < start) next
     if (end_ts != \"\" && ts >= end_ts) next
-
+$dedup_block
     model = \$2
     input = \$3 + 0
     output = \$4 + 0
@@ -543,6 +546,7 @@ calculate_project_breakdown() {
 
   local awk_pricing
   awk_pricing=$(get_awk_pricing_block)
+  local dedup_block; dedup_block=$(get_awk_dedup_block)
 
   # Iterate over project directories
   local project_dir
@@ -576,7 +580,7 @@ calculate_project_breakdown() {
          (.message.usage.cache_creation.ephemeral_5m_input_tokens // 0),
          (.message.usage.cache_creation.ephemeral_1h_input_tokens // 0),
          (.message.usage.cache_creation_input_tokens // 0),
-         (.message.usage.cache_read_input_tokens // 0)] | @tsv' "$jsonl_file" 2>/dev/null
+         (.message.usage.cache_read_input_tokens // 0), (.message.id // ""), (.requestId // ""), (.uuid // "")] | @tsv' "$jsonl_file" 2>/dev/null
     done | awk -F'\t' -v start="$range_start" -v end_ts="${range_end_iso:-}" "
     BEGIN {
 $awk_pricing
@@ -588,7 +592,7 @@ $awk_pricing
 
       if (ts < start) next
       if (end_ts != \"\" && ts >= end_ts) next
-
+$dedup_block
       model = \$2
       input = \$3 + 0
       output = \$4 + 0
@@ -671,6 +675,7 @@ calculate_burn_rate_analysis() {
 
   local awk_pricing
   awk_pricing=$(get_awk_pricing_block)
+  local dedup_block; dedup_block=$(get_awk_dedup_block)
 
   find "$search_path" -name "*.jsonl" -type f -mtime -$((find_days + 1)) 2>/dev/null | while read -r jsonl_file; do
     [[ -z "$jsonl_file" ]] && continue
@@ -681,7 +686,7 @@ calculate_burn_rate_analysis() {
        (.message.usage.cache_creation.ephemeral_5m_input_tokens // 0),
        (.message.usage.cache_creation.ephemeral_1h_input_tokens // 0),
        (.message.usage.cache_creation_input_tokens // 0),
-       (.message.usage.cache_read_input_tokens // 0)] | @tsv' "$jsonl_file" 2>/dev/null
+       (.message.usage.cache_read_input_tokens // 0), (.message.id // ""), (.requestId // ""), (.uuid // "")] | @tsv' "$jsonl_file" 2>/dev/null
   done | awk -F'\t' -v start="$range_start" -v end_ts="${range_end_iso:-}" "
   BEGIN {
 $awk_pricing
@@ -694,7 +699,7 @@ $awk_pricing
 
     if (ts < start) next
     if (end_ts != \"\" && ts >= end_ts) next
-
+$dedup_block
     model = \$2
     input = \$3 + 0
     output = \$4 + 0

--- a/tests/unit/test_cache_efficiency_block.bats
+++ b/tests/unit/test_cache_efficiency_block.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+
+# ============================================================================
+# cache_efficiency component: block-based, de-duplicated
+# ============================================================================
+# The cache_efficiency component represents cache hit rate for the current
+# 5-hour billing block (consistent with LIVE / burn_rate / block_projection).
+# It must derive from the de-duplicated window tokens, NOT the current turn's
+# native current_usage (which can read 0% right after a cache-creation turn).
+# ============================================================================
+
+load '../setup_suite'
+load '../helpers/test_helpers'
+
+setup() {
+    common_setup
+
+    source "$PROJECT_ROOT/lib/core.sh" || skip "core not available"
+    source "$PROJECT_ROOT/lib/security.sh" || skip "security not available"
+    source "$PROJECT_ROOT/lib/cache.sh" || skip "cache not available"
+    source "$PROJECT_ROOT/lib/json_fields.sh" || skip "json_fields not available"
+    source "$PROJECT_ROOT/lib/config.sh" || skip "config not available"
+    source "$PROJECT_ROOT/lib/cost.sh" || skip "cost not available"
+
+    # Stub component registration so the component file sources standalone
+    register_component() { return 0; }
+    source "$PROJECT_ROOT/lib/components/cache_efficiency.sh" || skip "component not available"
+
+    # Satisfy the `is_module_loaded "cost"` guard
+    STATUSLINE_MODULES_LOADED=("cost")
+
+    export CLAUDE_CONFIG_DIR="$TEST_TMP_DIR/claude"
+    mkdir -p "$CLAUDE_CONFIG_DIR/projects/-test-proj"
+    TEST_JSONL="$CLAUDE_CONFIG_DIR/projects/-test-proj/session.jsonl"
+}
+
+teardown() {
+    unset COMPONENT_USAGE_FIVE_HOUR_RESET STATUSLINE_INPUT_JSON
+    common_teardown
+}
+
+# id req uuid cache_read cache_creation ts
+_cache_entry() {
+    printf '{"type":"assistant","timestamp":"%s","requestId":"%s","uuid":"%s","message":{"id":"%s","model":"claude-opus-4-8","usage":{"input_tokens":0,"output_tokens":0,"cache_creation_input_tokens":%s,"cache_read_input_tokens":%s}}}\n' \
+        "$6" "$2" "$3" "$1" "$5" "$4"
+}
+
+_utc_iso_minutes_ago() {
+    local m="$1"
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        date -u -v-"${m}"M +%Y-%m-%dT%H:%M:%S.000Z
+    else
+        date -u -d "$m minutes ago" +%Y-%m-%dT%H:%M:%S.000Z
+    fi
+}
+
+@test "cache_efficiency reflects the deduped 5h block, not the current turn" {
+    export COMPONENT_USAGE_FIVE_HOUR_RESET="$(( $(date +%s) + 3600 ))"
+
+    # Current turn (native) would report 0% — must NOT be used.
+    export STATUSLINE_INPUT_JSON='{"context_window":{"current_usage":{"cache_read_input_tokens":0,"cache_creation_input_tokens":1000,"input_tokens":10}}}'
+
+    local ts; ts="$(_utc_iso_minutes_ago 10)"
+    # Block: cache_read 900000, cache_write 100000 => 90% hit.
+    # The duplicate copy must not skew the ratio.
+    {
+        _cache_entry msg_A req_A uuid_1 900000 100000 "$ts"
+        _cache_entry msg_A req_A uuid_2 900000 100000 "$ts"
+    } > "$TEST_JSONL"
+
+    collect_cache_efficiency_data
+    [ "$COMPONENT_CACHE_EFFICIENCY_INFO" = "Cache: 90% hit" ]
+}
+
+@test "cache_efficiency falls back to native current-turn when no active block" {
+    # No reset info -> no window -> fall back to native current_usage (75%).
+    unset COMPONENT_USAGE_FIVE_HOUR_RESET
+    export STATUSLINE_INPUT_JSON='{"context_window":{"current_usage":{"cache_read_input_tokens":3000,"cache_creation_input_tokens":1000}}}'
+    : > "$TEST_JSONL"
+
+    collect_cache_efficiency_data
+    [ "$COMPONENT_CACHE_EFFICIENCY_INFO" = "Cache: 75% hit" ]
+}

--- a/tests/unit/test_cost_dedup.bats
+++ b/tests/unit/test_cost_dedup.bats
@@ -1,0 +1,127 @@
+#!/usr/bin/env bats
+
+# ============================================================================
+# Cost de-duplication tests
+# ============================================================================
+# Claude Code re-logs the SAME assistant API response into transcripts on
+# session resume, compaction, and subagent sidechains — each copy carries the
+# original usage block. Anthropic bills each response (message.id) once, so
+# summing every JSONL occurrence overcounts cost/tokens (observed 6-20x in the
+# wild). Cost calculations must deduplicate by (message.id, requestId).
+# ============================================================================
+
+load '../setup_suite'
+load '../helpers/test_helpers'
+
+setup() {
+    common_setup
+
+    source "$PROJECT_ROOT/lib/core.sh" || skip "core not available"
+    source "$PROJECT_ROOT/lib/security.sh" || skip "security not available"
+    source "$PROJECT_ROOT/lib/cache.sh" || skip "cache not available"
+    source "$PROJECT_ROOT/lib/config.sh" || skip "config not available"
+    source "$PROJECT_ROOT/lib/cost.sh" || skip "cost not available"
+
+    # Isolated fake projects dir so cost functions never touch real transcripts
+    export CLAUDE_CONFIG_DIR="$TEST_TMP_DIR/claude"
+    mkdir -p "$CLAUDE_CONFIG_DIR/projects/-test-proj"
+    TEST_JSONL="$CLAUDE_CONFIG_DIR/projects/-test-proj/session.jsonl"
+}
+
+teardown() {
+    unset COMPONENT_USAGE_FIVE_HOUR_RESET
+    common_teardown
+}
+
+# Write one assistant entry. Args: msg_id req_id uuid output_tokens timestamp [input_tokens]
+_entry() {
+    local input="${6:-0}"
+    printf '{"type":"assistant","timestamp":"%s","requestId":"%s","uuid":"%s","message":{"id":"%s","model":"claude-opus-4-8","usage":{"input_tokens":%s,"output_tokens":%s,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}\n' \
+        "$5" "$2" "$3" "$1" "$input" "$4"
+}
+
+# Write one assistant entry WITHOUT a message.id. Args: req_id uuid output_tokens timestamp
+_entry_noid() {
+    printf '{"type":"assistant","timestamp":"%s","requestId":"%s","uuid":"%s","message":{"model":"claude-opus-4-8","usage":{"input_tokens":0,"output_tokens":%s,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}\n' \
+        "$4" "$1" "$2" "$3"
+}
+
+# Cross-platform "now minus N minutes" as UTC ISO-8601 (with millis + Z)
+_utc_iso_minutes_ago() {
+    local m="$1"
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        date -u -v-"${m}"M +%Y-%m-%dT%H:%M:%S.000Z
+    else
+        date -u -d "$m minutes ago" +%Y-%m-%dT%H:%M:%S.000Z
+    fi
+}
+
+# ----------------------------------------------------------------------------
+# calculate_cost_in_range (REPO/DAY/7DAY/30DAY foundation)
+# ----------------------------------------------------------------------------
+
+@test "calculate_cost_in_range counts a duplicated message.id only once" {
+    # Opus 4.8 output = \$25/M. msg_A is logged TWICE (resume/sidechain copy),
+    # msg_B once. Correct cost = 2 unique x 1M output x \$25 = \$50.00
+    {
+        _entry msg_A req_A uuid_1 1000000 "2026-05-30T01:00:00.000Z"
+        _entry msg_A req_A uuid_2 1000000 "2026-05-30T01:00:00.000Z"
+        _entry msg_B req_B uuid_3 1000000 "2026-05-30T01:05:00.000Z"
+    } > "$TEST_JSONL"
+
+    run calculate_cost_in_range "2026-05-30T00:00:00"
+    [ "$status" -eq 0 ]
+    [ "$output" = "50.00" ]
+}
+
+@test "calculate_cost_in_range keeps distinct messages with same requestId" {
+    # Same requestId can appear on different responses; the message.id differs,
+    # so both must count: 2 x \$25 = \$50.00
+    {
+        _entry msg_A req_SHARED uuid_1 1000000 "2026-05-30T01:00:00.000Z"
+        _entry msg_B req_SHARED uuid_2 1000000 "2026-05-30T01:01:00.000Z"
+    } > "$TEST_JSONL"
+
+    run calculate_cost_in_range "2026-05-30T00:00:00"
+    [ "$status" -eq 0 ]
+    [ "$output" = "50.00" ]
+}
+
+@test "calculate_cost_in_range does not over-dedupe entries missing message.id" {
+    # No message.id -> cannot prove duplication -> fall back to per-line uuid,
+    # so two distinct uuids both count: 2 x \$25 = \$50.00 (never collapse to \$25)
+    {
+        _entry_noid req_A uuid_1 1000000 "2026-05-30T01:00:00.000Z"
+        _entry_noid req_B uuid_2 1000000 "2026-05-30T01:01:00.000Z"
+    } > "$TEST_JSONL"
+
+    run calculate_cost_in_range "2026-05-30T00:00:00"
+    [ "$status" -eq 0 ]
+    [ "$output" = "50.00" ]
+}
+
+# ----------------------------------------------------------------------------
+# calculate_window_tokens (burn rate + projection token counts)
+# ----------------------------------------------------------------------------
+
+@test "calculate_window_tokens dedupes duplicated responses in the 5h window" {
+    # Window = resets_at - 5h. Put reset 1h ahead so window started 4h ago.
+    export COMPONENT_USAGE_FIVE_HOUR_RESET="$(( $(date +%s) + 3600 ))"
+
+    local ts1 ts2
+    ts1="$(_utc_iso_minutes_ago 10)"
+    ts2="$(_utc_iso_minutes_ago 9)"
+    {
+        _entry msg_A req_A uuid_1 1000000 "$ts1" 500000
+        _entry msg_A req_A uuid_2 1000000 "$ts1" 500000   # duplicate
+        _entry msg_B req_B uuid_3 1000000 "$ts2" 500000
+    } > "$TEST_JSONL"
+
+    # total:input:output:cache_read:cache_write — 2 unique entries:
+    # output = 2,000,000 ; input = 1,000,000 ; total = 3,000,000
+    run calculate_window_tokens
+    [ "$status" -eq 0 ]
+    local output_tokens
+    output_tokens=$(echo "$output" | cut -d: -f3)
+    [ "$output_tokens" = "2000000" ]
+}


### PR DESCRIPTION
## Problem

Claude Code re-logs the same assistant API response into transcripts on session **resume, compaction, and subagent sidechains** — each copy keeps its original `usage` block (same `message.id` + `requestId`, distinct `uuid`). Every cost pipeline summed all copies with no de-duplication, so the same tokens were counted many times.

Measured on a live 5-hour window: **2,453 logged entries → 402 unique** `(message.id, requestId)` pairs (6.2× row duplication, **19.7× cost inflation**):

| Field | Before | After (deduped) |
|---|---|---|
| LIVE | $2543 | ~$137 |
| burn rate | $3399/hr | ~$110/hr |
| Est (projection) | $16941 (595.8M) | ~$540 (6.4M) |
| DAY | $2938 | ~$265 |
| 30DAY | $21926 | ~$7244 |

## Fix

**1 — De-duplicate by `(message.id, requestId)`** across every JSONL-summing pipeline. New shared `get_awk_dedup_block()` in `pricing.sh`; jq filters append `message.id`/`requestId`/`uuid` as the last three TSV columns. Falls back to `uuid` then record number so distinct calls are never wrongly collapsed. Covers `api_live` (LIVE + window tokens), `native_calc` (REPO/DAY/7DAY/30DAY), `report_calc` (all 5 CLI breakdowns), `recommendations`, commit attribution, and MCP attribution (deduped by message.id + content index so parallel tool calls still count). `session.sh` and idle-burn are unchanged (no token summing).

**2 — `cache_efficiency` now reads the de-duplicated 5h block** instead of the current turn's native `current_usage` (which reads 0% right after a cache-creation turn). Falls back to native only when there is no active block.

## Tests

- 6 new tests (`test_cost_dedup.bats`, `test_cache_efficiency_block.bats`), TDD — each watched fail before the fix.
- 175 existing cost/report/native/recommendations tests pass. The two unrelated non-passes (`migrate_legacy_cache`, `cache_integration`) fail identically on `nightly` (pre-existing/environmental).
- Verified end-to-end against real transcripts: full render now shows sane cost numbers and `Cache: 91% hit`.

Same approach ccusage and Claude Code's own cost tracker use.
