### PR TITLE
ci: retire broken Homebrew auto-bump job from Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,39 +122,3 @@ jobs:
           git push origin latest --force
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  update-homebrew:
-    name: Update Homebrew Formula
-    runs-on: ubuntu-latest
-    needs: [validate, release]
-
-    steps:
-      - name: Compute tarball SHA256
-        id: sha
-        run: |
-          VERSION=${{ needs.validate.outputs.version }}
-          SHA=$(curl -sSL "https://github.com/rz1989s/claude-code-statusline/archive/refs/tags/v${VERSION}.tar.gz" | shasum -a 256 | awk '{print $1}')
-          echo "sha256=$SHA" >> $GITHUB_OUTPUT
-
-      - name: Checkout homebrew-tap
-        uses: actions/checkout@v6
-        with:
-          repository: rz1989s/homebrew-tap
-          ssh-key: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
-          persist-credentials: true
-
-      - name: Update formula version and SHA
-        run: |
-          VERSION=${{ needs.validate.outputs.version }}
-          SHA=${{ steps.sha.outputs.sha256 }}
-          sed -i "s|url \"https://github.com/rz1989s/claude-code-statusline/archive/refs/tags/v.*\.tar\.gz\"|url \"https://github.com/rz1989s/claude-code-statusline/archive/refs/tags/v${VERSION}.tar.gz\"|" Formula/claude-code-statusline.rb
-          sed -i "s|sha256 \".*\"|sha256 \"${SHA}\"|" Formula/claude-code-statusline.rb
-
-      - name: Commit and push
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin git@github.com:rz1989s/homebrew-tap.git
-          git add Formula/claude-code-statusline.rb
-          git commit -m "bump claude-code-statusline to v${{ needs.validate.outputs.version }}"
-          git push origin main


### PR DESCRIPTION
## Retire the broken Homebrew auto-bump job

Closes #361.

The `Release` workflow's `update-homebrew` job has failed on **every** release (v2.25.4, v2.25.5, v2.25.6): its SSH checkout of `rz1989s/homebrew-tap` exits 128 because the `HOMEBREW_TAP_DEPLOY_KEY` secret's public half is no longer a deploy key on the tap (the tap's deploy-key list is empty). Every other job in the workflow passes — the job is pure noise that reds-out each release run.

The `/claude-code-statusline:compat-update` skill bumps the tap **manually** (Step 12) on every release, verified working 3×, so this job is redundant. Removing it kills the perpetual ❌ with zero secret-management overhead.

### Change
- Delete the `update-homebrew` job from `.github/workflows/release.yml` (−36 lines)

### Verification
- `release.yml` still valid YAML; remaining jobs: `validate`, `test`, `release` (trigger `on: push tags v*.*.*` intact)
- No other workflow/job references `update-homebrew`, `homebrew-tap`, or `HOMEBREW_TAP_DEPLOY_KEY`

_Alternative considered & rejected_: re-provisioning the deploy key (ed25519 keypair → write deploy key on tap → refresh secret). The manual path already works every release, so retiring avoids maintaining an expiring credential.
